### PR TITLE
switch to long format command line options

### DIFF
--- a/jujufly/jujufly.c
+++ b/jujufly/jujufly.c
@@ -78,13 +78,13 @@ typedef struct juju_db {
     TAILQ_ENTRY(juju_db) entries;
 } juju_db;
 
-static size_t db_size = DB_SIZE;
-static char *db_name = "db";
-static int ndatabases = 100;
+size_t db_size = DB_SIZE;
+char *db_file = "db";
+int ndatabases = 100;
 
-static int fieldc;
-static char **fieldv;
-static int *field_indexed;
+int fieldc;
+char **fieldv;
+int *field_indexed;
 Pvoid_t field_array = (PWord_t)NULL;
 
 TAILQ_HEAD(db_list, juju_db) dbs;
@@ -336,7 +336,7 @@ void roll_dbs()
                             jjdb->filename, strerror(errno));
                     exit(1);                    
                 } else {
-                    sprintf(buf, "%s.%03d", db_name, i+1);
+                    sprintf(buf, "%s.%03d", db_file, i+1);
                     rename(jjdb->filename, buf);
                     free(jjdb->filename);
                     jjdb->filename = strdup(buf);
@@ -354,7 +354,7 @@ void open_all_dbs()
     char buf[1024];
     int i;
     
-    sprintf(buf, "%s.[0-9][0-9][0-9]", db_name);
+    sprintf(buf, "%s.[0-9][0-9][0-9]", db_file);
     fprintf(stderr, "looking for: %s\n", buf);
     glob(buf, 0, NULL, &g);
     for (i=0; i < GLOBC(g) && i < ndatabases; i++) {
@@ -386,7 +386,7 @@ void put_cb(struct evhttp_request *req, struct evbuffer *evb,void *ctx)
             while (append_record(jjdb, s) == false) {
                 roll_dbs();
                 jjdb = calloc(1, sizeof(*jjdb));
-                asprintf(&jjdb->filename, "%s.000", db_name);
+                asprintf(&jjdb->filename, "%s.000", db_file);
                 open_db(jjdb);
                 TAILQ_INSERT_HEAD(&dbs, jjdb, entries);
             }
@@ -686,56 +686,30 @@ void dbstats_cb(struct evhttp_request *req, struct evbuffer *evb,void *ctx)
     evhttp_send_reply(req, HTTP_OK, "OK", evb);
 }
 
-void info()
-{
-    fprintf(stdout, "%s: time series server with indices.\n", NAME);
-    fprintf(stdout, "Version %s, "
-            "https://github.com/bitly/simplehttp/tree/master/jujufly\n",
-            VERSION);
-}
 
-void usage()
-{
-    fprintf(stderr, "Provides search access to time based streams\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "usage: jujufly\n");
-    fprintf(stderr, "\t-f /path/to/dbfile\n");
-    fprintf(stderr, "\t-n field1,field2,field3 (field names)\n");
-    fprintf(stderr, "\t-i field2,field3 (index by field name)\n");
-    fprintf(stderr, "\t-a 127.0.0.1 (address to listen on)\n");
-    fprintf(stderr, "\t-p 8080 (port to listen on)\n");
-    fprintf(stderr, "\t-D (daemonize)\n");
-    fprintf(stderr, "\n");
-    exit(1);
+int version_cb(int value) {
+    fprintf(stdout, "Version: %s\n", VERSION);
+    return 0;
 }
 
 int main(int argc, char **argv)
 {
-    int i, j, ch, indexc=0;
+    int i, j, indexc=0;
     Word_t *val;
     char **indexv;
     
-    opterr = 0;
-    while ((ch = getopt(argc, argv, "f:i:n:h")) != -1) {
-        if (ch == '?') {
-            optind--;
-            break;
-        }
-        switch (ch) {
-        case 'f':
-            db_name = strdup(optarg);
-            break;
-        case 'n':
-            fieldv = split_keys(optarg, &fieldc, ',');
-            break;
-        case 'i':
-            indexv = split_keys(optarg, &indexc, ',');
-            break;
-        case 'h':
-            usage();
-            exit(1);
-        }
+    define_simplehttp_options();
+    option_define_str("db_file", OPT_REQUIRED, "db", &db_file, NULL, NULL);
+    option_define_str("field_names", OPT_REQUIRED, NULL, NULL, NULL, "field1,field2,field3 (field names)");
+    option_define_str("field_index", OPT_REQUIRED, NULL, NULL, NULL, "field2,field3 (index by field name)");
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
+    
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
     }
+    
+    fieldv = split_keys(option_get_str("field_names"), &fieldc, ',');
+    indexv = split_keys(option_get_str("field_index"), &indexc, ',');
 
     field_indexed = calloc(fieldc+1, sizeof(int));
     for (i=0; i < indexc; i++) {
@@ -755,6 +729,7 @@ int main(int argc, char **argv)
     simplehttp_set_cb("/search*", search_cb, NULL);
     simplehttp_set_cb("/printidx*", printidx_cb, NULL);
     simplehttp_set_cb("/dbstats*", dbstats_cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
     return 0;
 }

--- a/ps_to_file/Makefile
+++ b/ps_to_file/Makefile
@@ -5,7 +5,7 @@ LIBSIMPLEHTTP_INC ?= $(LIBSIMPLEHTTP)/..
 LIBSIMPLEHTTP_LIB ?= $(LIBSIMPLEHTTP)
 
 CFLAGS = -I. -I$(LIBSIMPLEHTTP_INC) -I$(LIBEVENT)/include -g
-LIBS = -L. -L$(LIBSIMPLEHTTP_LIB) -L$(LIBEVENT)/lib -levent -lpubsubclient
+LIBS = -L. -L$(LIBSIMPLEHTTP_LIB) -L$(LIBEVENT)/lib -levent -lpubsubclient -lsimplehttp -lm
 
 all: ps_to_file
 

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -5,11 +5,19 @@ pubsub (short for publish/subscribe) is a server that brokers new messages
 to all connected subscribers at the time a message is received.
 http://en.wikipedia.org/wiki/Publish/subscribe
 
-Cmdline usage:
+Commandline options:
 
-    -a 0.0.0.0 (address to bind to)
-    -p 8080 (port to bind to)
-    -D daemonize (default off)
+    --address=<str>        address to listen on
+                           default: 0.0.0.0
+    --daemon               daemonize process
+    --enable-logging       request logging
+    --group=<str>          run as this group
+    --help                 list usage
+    --port=<int>           port to listen on
+                           default: 8080
+    --root=<str>           chdir and run from this directory
+    --user=<str>           run as this user
+    --version              
 
 API endpoints:
 

--- a/pubsub/pubsub.c
+++ b/pubsub/pubsub.c
@@ -8,6 +8,7 @@
 
 #define BOUNDARY "xXPubSubXx"
 #define MAX_PENDING_DATA 1024*1024*50
+#define VERSION "1.1"
 
 int ps_debug = 0;
 
@@ -288,16 +289,30 @@ void sub_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx)
     evhttp_clear_headers(&args);
 }
 
+int version_cb(int value) {
+    fprintf(stdout, "Version: %s\n", VERSION);
+    return 0;
+}
+
 int
 main(int argc, char **argv)
 {
+    
+    define_simplehttp_options();
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
+    
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
+    }
+    
     TAILQ_INIT(&clients);
     simplehttp_init();
     simplehttp_set_cb("/pub*", pub_cb, NULL);
     simplehttp_set_cb("/sub*", sub_cb, NULL);
     simplehttp_set_cb("/stats*", stats_cb, NULL);
     simplehttp_set_cb("/clients", clients_cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
 
     return 0;
 }

--- a/qrencode/qrencode.c
+++ b/qrencode/qrencode.c
@@ -185,17 +185,23 @@ main(int argc, char **argv)
 
     char *outfile = "/tmp/qrencode.png";
 
+    define_simplehttp_options();
+    option_define_str("temp_file", OPT_OPTIONAL, "/tmp/qrencode.png", &outfile, NULL, NULL);
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
+    }
+
     fp = fopen(outfile, "a+");
     if(fp == NULL) {
         fprintf(stderr, "Failed to create file: %s\n", outfile);
         perror(NULL);
         exit(EXIT_FAILURE);
     }
-    //unlink(outfile);
 
     simplehttp_init();
     simplehttp_set_cb("/qr*", cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
     
     fclose(fp);
     return 0;

--- a/simplegeo/simplegeo.c
+++ b/simplegeo/simplegeo.c
@@ -28,16 +28,16 @@ static int CmpElem(const void *e1, const void *e2);
 
 struct event ev;
 struct timeval tv = {RECONNECT,0};
-static char *db_host = "0.0.0.0";
-static int db_port = 1978;
-static TCRDB *rdb;
-static int db_status;
-static char *g_progname;
+char *db_host = "127.0.0.1";
+int db_port = 1978;
+TCRDB *rdb;
+int db_status;
+char *g_progname;
 
-static double pi;
-static double longDistance[181];
-static double latDistance = 69.169144;
-static double radius = 3958.75587;
+double pi;
+double longDistance[181];
+double latDistance = 69.169144;
+double radius = 3958.75587;
 
 typedef struct Geo_Result {
     int id;
@@ -447,16 +447,6 @@ void search_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx)
     finalize_json(req, evb, &args, jsobj);
 }
 
-void usage()
-{
-    fprintf(stderr, "%s: http wrapper for Tokyo Tyrant\n", g_progname);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "usage:\n");
-    fprintf(stderr, "  %s [-tchost 0.0.0.0] [-tcport 1978]\n", g_progname);
-    fprintf(stderr, "\n");
-    exit(1);
-}
-
 int
 main(int argc, char **argv)
 {
@@ -464,17 +454,11 @@ main(int argc, char **argv)
     double magic, rlat, s, c;
     int lat;
     
-    g_progname = argv[0];
-    for (i=1; i < argc; i++) {
-        if(!strcmp(argv[i], "-tchost")) {
-            if(++i >= argc) usage();
-            db_host = argv[i];
-        } else if(!strcmp(argv[i], "-tcport")) {
-            if(++i >= argc) usage();
-            db_port = tcatoi(argv[i]);
-        } else if (!strcmp(argv[i], "-help")) {
-            usage();
-        }
+    define_simplehttp_options();
+    option_define_str("ttserver_host", OPT_OPTIONAL, "127.0.0.1", &db_host, NULL, NULL);
+    option_define_int("ttserver_port", OPT_OPTIONAL, 1978, &db_port, NULL, NULL);
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
     }
     
     pi = atan(1.0)*4;
@@ -495,13 +479,14 @@ main(int argc, char **argv)
     simplehttp_set_cb("/del*", del_cb, NULL);
     simplehttp_set_cb("/distance*", distance_cb, NULL);
     simplehttp_set_cb("/box*", box_cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
     
     if (!tcrdbclose(rdb)) {
         errCode = tcrdbecode(rdb);
         fprintf(stderr, "close error: %s\n", tcrdberrmsg(errCode));
     }
     tcrdbdel(rdb);
+    free_options();
 
     return 0;
 }

--- a/simplehttp/Makefile
+++ b/simplehttp/Makefile
@@ -1,14 +1,14 @@
 LIBEVENT ?= /usr/local
 TARGET ?= /usr/local
 
-CFLAGS = -I. -I$(LIBEVENT)/include -Wall -g -O2
+CFLAGS = -I. -I$(LIBEVENT)/include -Wall -g
 LIBS = -L. -L$(LIBEVENT)/lib -levent -lm
 
 AR = ar
 AR_FLAGS = rc
 RANLIB = ranlib
 
-libsimplehttp.a: simplehttp.o async_simplehttp.o timer.o log.o util.o stat.o request.o
+libsimplehttp.a: simplehttp.o async_simplehttp.o timer.o log.o util.o stat.o request.o options.o
 	/bin/rm -f $@
 	$(AR) $(AR_FLAGS) $@ $^
 	$(RANLIB) $@
@@ -23,7 +23,13 @@ install:
 	/usr/bin/install -d $(TARGET)/include/simplehttp/
 	/usr/bin/install libsimplehttp.a $(TARGET)/lib/
 	/usr/bin/install simplehttp.h $(TARGET)/include/simplehttp/
+	/usr/bin/install simplehttp.h $(TARGET)/include/simplehttp/
 	/usr/bin/install queue.h $(TARGET)/include/simplehttp/
+	/usr/bin/install uthash.h $(TARGET)/include/simplehttp/
+	/usr/bin/install utlist.h $(TARGET)/include/simplehttp/
+	/usr/bin/install utstring.h $(TARGET)/include/simplehttp/
+	/usr/bin/install utarray.h $(TARGET)/include/simplehttp/
+	/usr/bin/install options.h $(TARGET)/include/simplehttp/
 
 clean:
 	rm -rf *.a *.o testserver *.dSYM

--- a/simplehttp/options.c
+++ b/simplehttp/options.c
@@ -49,6 +49,7 @@ int option_sort(struct Option *a, struct Option *b)
 
 int help_cb(int value) {
     option_help();
+    free_options();
     return 0;
 }
 

--- a/simplehttp/options.c
+++ b/simplehttp/options.c
@@ -1,0 +1,416 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <libgen.h> // for basename()
+
+#include "options.h"
+#include "uthash.h"
+
+enum option_type {
+    OPT_BOOL = 1,
+    OPT_STR = 2,    
+    OPT_INT = 3,
+    OPT_FLOAT = 4,
+    OPT_CHAR = 5,
+};
+
+struct Option {
+    char *option_name;
+    int option_type;
+    int required;
+    int found;
+    char *value_str;
+    int value_int;
+    char value_char;
+    
+    int default_int;
+    char *default_str;
+    char default_char;
+    int *dest_int;
+    char **dest_str;
+    char *dest_char;
+    int(*cb_int)(int value);
+    int(*cb_str)(char *value);
+    int(*cb_char)(char value);
+    
+    char *help;
+    UT_hash_handle hh;
+};
+
+struct Option *option_list = NULL;
+char *option_process_name = NULL;
+
+int format_option_name(char *option_name);
+int option_sort(struct Option *a, struct Option *b)
+{
+    return strcmp(a->option_name, b->option_name);
+}
+
+int help_cb(int value) {
+    option_help();
+    return 0;
+}
+
+/*
+handle the following option formats
+-p {value} -p={value} (for single character option_list)
+--port {value} --port={value} (for longer option_list)
+--debug (implicit true)
+--debug=true|false
+
+@return 1 when parsing was successful. 0 when not
+*/
+int option_parse_command_line(int argc, char **argv) {
+    int i;
+    char *option_str;
+    char *option_name;
+    size_t option_name_len;
+    char *value;
+    struct Option *option, *tmp_option;
+    
+    // lazily define help option
+    HASH_FIND_STR(option_list, "help", option);
+    if (!option) {
+        option_define_bool("help", OPT_OPTIONAL, 0, NULL, help_cb, "list usage");
+    }
+    
+    option_process_name=basename(argv[0]);
+    for (i=1; i < argc; i++) {
+        // fprintf(stdout, "DEBUG: option %d : %s\n", i, argv[i]);
+        option_str = argv[i];
+        // find the option_name
+        if (strncmp(option_str, "--", 2) != 0) {
+            fprintf(stderr, "ERROR: invalid argument \"%s\"\n", option_str);
+            return 0;
+        }
+        option_name = strchr(option_str, '-');
+        option_name++;
+        option_name = strchr(option_name, '-');
+        option_name++;
+        value = strchr(option_name, '=');
+        option_name_len = strlen(option_str) - (option_name - option_str);
+        if (value != NULL) {
+            option_name_len -= strlen(value);
+            *value = '\0';
+            value++;
+        }
+        if (format_option_name(option_name)) {
+            fprintf(stderr, "ERROR: unknown option \"--%s\"\n", option_name); // option_str ?
+            return 0;
+        }
+        HASH_FIND(hh, option_list, option_name, option_name_len, option);
+        if (!option) {
+            fprintf(stderr, "ERROR: unknown option \"--%s\"\n", option_name); // option_str ?
+            return 0;
+        }
+        if (option->option_type != OPT_BOOL && value == NULL) {
+            fprintf(stderr, "ERROR: missing argument for \"--%s\"", option_name);
+            return 0;
+        }
+        
+        // TODO: strip quotes from value
+        
+        switch(option->option_type) {
+        case OPT_CHAR:
+            if (strlen(value) != 1) {
+                fprintf(stderr, "ERROR: argument for --%s must be a single character (got %s)\n", option_name, value);
+                return 0;
+            }
+            option->value_char = value[0];
+            if (option->cb_char) {
+                if (!option->cb_char(option->value_char)) {
+                    return 0;
+                }
+            }
+            if (option->dest_char) {
+                *(option->dest_char) = option->value_char;
+            }
+            break;
+        case OPT_STR:
+            option->value_str = value;
+            if (option->cb_str) {
+                if(!option->cb_str(value)){
+                    return 0;
+                }
+            }
+            if (option->dest_str) {
+                *(option->dest_str) = strdup(value);
+            }
+            break;
+        case OPT_BOOL:
+            if (value == NULL) {
+                option->value_int = 1;
+            } else if (strcasecmp(value, "false") == 0) {
+                option->value_int = 0;
+            } else if (strcasecmp(value, "true") == 0) {
+                option->value_int = 1;
+            } else {
+                fprintf(stderr, "ERROR: unknown value for --%s (%s). should be \"true\" or \"false\"\n", option->option_name, value);
+                return 0;
+            }
+            if (option->cb_int) {
+                if(!option->cb_int(option->value_int)) {
+                    return 0;
+                };
+            }
+            if (option->dest_int) {
+                *(option->dest_int) = option->value_int;
+            }
+            break;
+        case OPT_INT:
+            option->value_int = atoi(value);
+            if (option->cb_int) {
+                if(!option->cb_int(option->value_int)) {
+                    return 0;
+                }
+            }
+            if (option->dest_int) {
+                *(option->dest_int) = option->value_int;
+            }
+            break;
+        }
+        option->found++;
+    }
+    
+    // check for not found entries
+    HASH_ITER(hh, option_list, option, tmp_option) {
+        if (option->required == OPT_REQUIRED && option->found == 0) {
+            fprintf(stderr, "ERROR: required option --%s not present\n", option->option_name);
+            fprintf(stderr, "       for a complete list of options use --help\n");
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* 
+@returns -1 if option not found or not defined
+*/
+int option_get_int(const char *option_name) {
+    struct Option *option;
+    char *tmp_option_name = strdup(option_name);
+    if (format_option_name(tmp_option_name)) {
+        free(tmp_option_name);
+        return -1;
+    }
+    HASH_FIND_STR(option_list, tmp_option_name, option);
+    free(tmp_option_name);
+    if (!option) {
+        return -1;
+    }
+    if (option->option_type != OPT_INT && option->option_type != OPT_BOOL) {return -1;}
+    if (option->found) {
+        return option->value_int;
+    }
+    return option->default_int;
+}
+
+char *option_get_str(const char *option_name) {
+    struct Option *option;
+    char *tmp_option_name = strdup(option_name);
+    if (format_option_name(tmp_option_name)) {
+        free(tmp_option_name);
+        return NULL;
+    }
+    HASH_FIND_STR(option_list, tmp_option_name, option);
+    free(tmp_option_name);
+    if (!option) {return NULL;}
+    if (option->option_type != OPT_STR) {return NULL;}
+    if (option->found) {
+        return option->value_str;
+    }
+    return option->default_str;
+}
+
+char option_get_char(const char *option_name) {
+    struct Option *option;
+    char *tmp_option_name = strdup(option_name);
+    if (format_option_name(tmp_option_name)) {
+        free(tmp_option_name);
+        return '\0';
+    }
+    HASH_FIND_STR(option_list, tmp_option_name, option);
+    free(tmp_option_name);
+    if (!option) {return '\0';}
+    if (option->option_type != OPT_CHAR) {return '\0';}
+    if (option->found) {
+        return option->value_char;
+    }
+    return option->default_char;
+}
+
+struct Option *new_option(const char *option_name, int required, const char *help){
+    struct Option *option;
+    char *tmp_option_name = strdup(option_name);
+    if (format_option_name(tmp_option_name)) {
+        fprintf(stderr, "ERROR: option %s is invalid\n", option_name);
+        free(tmp_option_name);
+        return NULL;
+    }
+
+    HASH_FIND_STR(option_list, tmp_option_name, option);
+    if (option){
+        fprintf(stderr, "ERROR: option %s is already defined\n", tmp_option_name);
+        return NULL;
+    }
+    option = malloc(sizeof(struct Option));
+    option->option_name = tmp_option_name;
+    option->required = required;
+    option->found = 0;
+    option->value_str = NULL;
+    option->value_int = 0;
+    option->value_char = '\0';
+    option->cb_int = NULL;
+    option->default_int = 0;
+    option->dest_int = NULL;
+    option->cb_str = NULL;
+    option->default_str = NULL;
+    option->dest_str = NULL;
+    option->cb_char = NULL;
+    option->default_char = 0;
+    option->dest_char = NULL;
+    option->help = NULL;
+    if (help) {
+        option->help = strdup(help);
+    }
+    //fprintf(stdout, "adding option %s to option_list %p\n", option->option_name, option);
+    HASH_ADD_KEYPTR(hh, option_list, option->option_name, strlen(option->option_name), option);
+    return option;
+}
+
+int option_define_int(const char *option_name, int required, int default_val, int *dest, int(*cb)(int value), const char *help) {
+    struct Option *option = new_option(option_name, required, help);
+    if (!option) {return -1;}
+    option->option_type = OPT_INT;
+    option->default_int = default_val;
+    option->dest_int = dest;
+    option->cb_int = cb;
+    return 1;
+}
+
+int option_define_str(const char *option_name, int required, char *default_val, char **dest, int(*cb)(char *value), const char *help) {
+    struct Option *option = new_option(option_name, required, help);
+    if (!option) {return -1;}
+    option->option_type = OPT_STR;
+    if (default_val) {
+        option->default_str = strdup(default_val);
+    }
+    option->dest_str = dest;
+    option->cb_str = cb;
+    return 1;
+}
+
+int option_define_bool(const char *option_name, int required, int default_val, int *dest, int(*cb)(int value), const char *help) {
+    struct Option *option = new_option(option_name, required, help);
+    if (!option) {return -1;}
+    option->option_type = OPT_BOOL;
+    option->default_int = default_val;
+    option->dest_int = dest;
+    option->cb_int = cb;
+    return 1;
+}
+
+int option_define_char(const char *option_name, int required, char default_val, char *dest, int(*cb)(char value), const char *help) {
+    struct Option *option = new_option(option_name, required, help);
+    if (!option) {return -1;}
+    option->option_type = OPT_CHAR;
+    option->default_char = default_val;
+    option->dest_char = dest;
+    option->cb_char = cb;
+    return 1;
+}
+
+void option_help() {
+    struct Option *option, *tmp_option;
+    char buffer[1024] = {'\0'};
+    
+    // lazily define help option
+    HASH_FIND_STR(option_list, "help", option);
+    if (!option) {
+        option_define_bool("help", OPT_OPTIONAL, 0, NULL, help_cb, "list usage");
+    }
+    
+    fprintf(stdout, "\n");
+    fprintf(stdout, "%s accepts the following options, listed alphabetically.\n\n", option_process_name);
+    fprintf(stdout, "OPTIONS\n");
+    
+    HASH_SORT(option_list, option_sort);
+    HASH_ITER(hh, option_list, option, tmp_option) {
+        switch(option->option_type) {
+        case OPT_STR:
+            sprintf(buffer, "--%s=<str>", option->option_name);
+            break;
+        case OPT_CHAR:
+            sprintf(buffer, "--%s=<char>", option->option_name);
+            break;
+        case OPT_INT:
+            sprintf(buffer, "--%s=<int>", option->option_name);
+            break;
+        case OPT_BOOL:
+            if (option->default_int != 0) {
+                sprintf(buffer, "--%s=True|False", option->option_name);
+            } else {
+                sprintf(buffer, "--%s", option->option_name);
+            }
+            break;
+        }
+        fprintf(stdout, "  %-22s", buffer);
+        if (option->help) {
+            fprintf(stdout, " %s", option->help);
+        }
+        fprintf(stdout, "\n");
+        switch(option->option_type) {
+        case OPT_CHAR:
+            if (option->default_char) {
+                fprintf(stdout, "%25sdefault:%c\n", "", option->default_char);
+            }
+            break;
+        case OPT_STR:
+            if (option->default_str) {
+                if (isatty(fileno(stdout))) {
+                    fprintf(stdout, "%25sdefault: %c[1m%s%c[0m\n", "", 27, option->default_str, 27);
+                } else {
+                    fprintf(stdout, "%25sdefault: %s\n", "", option->default_str);
+                }
+            }
+            break;
+        case OPT_INT:
+            if (option->default_int) {
+                fprintf(stdout, "%25sdefault: %d\n", "", option->default_int);
+            }
+            break;
+        default:
+            break;
+        }
+    }
+    fprintf(stdout, "\n");
+}
+
+void free_options() {
+    struct Option *option, *tmp_option;
+    HASH_ITER(hh, option_list, option, tmp_option) {
+        HASH_DELETE(hh, option_list, option);
+        free(option->option_name);
+        free(option->help);
+        free(option->default_str);
+        free(option);
+    }
+}
+
+int format_option_name(char *option_name) {
+    char *ptr = option_name;
+    char *end = ptr + strlen(option_name);
+    while(ptr <= end && *ptr != '\0') {
+        if (*ptr >= 'A' && *ptr <= 'Z') {
+            *ptr += 32;
+        } else if (*ptr == '_') {
+            *ptr = '-';
+        } else if (*ptr < 48 && *ptr != 45){
+            fprintf(stderr, "invalid char %c\n", *ptr);
+            return 1;
+        }
+        ptr++;
+    }
+    return 0;
+}

--- a/simplehttp/options.h
+++ b/simplehttp/options.h
@@ -1,0 +1,22 @@
+#ifndef _SIMPLEHTTP_OPTIONS_H
+#define _SIMPLEHTTP_OPTIONS_H
+
+enum required_option {
+	OPT_REQUIRED = 1,
+	OPT_OPTIONAL = 0
+};
+
+int option_parse_command_line(int argc, char **argv);
+int option_define_int(const char *option_name, int required, int default_val, int *dest, int(*cb)(int value), const char *help);
+int option_define_str(const char *option_name, int required, char *default_val, char **dest, int(*cb)(char *value), const char *help);
+int option_define_bool(const char *option_name, int required, int default_val, int *dest, int(*cb)(int value), const char *help);
+int option_define_char(const char *option_name, int required, char default_val, char *dest, int(*cb)(char value), const char *help);
+
+void option_help();
+int option_get_int(const char *option_name);
+char *option_get_str(const char *option_name);
+char option_get_char(const char *option_name);
+
+void free_options();
+
+#endif

--- a/simplehttp/request.c
+++ b/simplehttp/request.c
@@ -8,7 +8,7 @@
 #include "request.h"
 #include "stat.h"
 
-extern int verbose;
+extern int simplehttp_logging;
 
 struct simplehttp_request *simplehttp_request_new(struct evhttp_request *req, uint64_t id)
 {
@@ -88,7 +88,7 @@ void simplehttp_request_finish(struct evhttp_request *req, struct simplehttp_req
         simplehttp_stats_store(s_req->index, req_time);
     }
     
-    if (verbose) {
+    if (simplehttp_logging) {
         sprintf(id_buf, "%"PRIu64, s_req->id);
         simplehttp_log("", req, req_time, id_buf);
     }

--- a/simplehttp/simplehttp.c
+++ b/simplehttp/simplehttp.c
@@ -16,6 +16,7 @@
 #include "simplehttp.h"
 #include "stat.h"
 #include "request.h"
+#include "options.h"
 
 typedef struct cb_entry {
     char *path;
@@ -25,10 +26,11 @@ typedef struct cb_entry {
 } cb_entry;
 TAILQ_HEAD(, cb_entry) callbacks;
 
-static int debug = 0;
-int verbose = 0;
+int simplehttp_logging = 0;
 int callback_count = 0;
 uint64_t request_count = 0;
+
+int help_cb(int *value);
 
 static void ignore_cb(int sig, short what, void *arg)
 {
@@ -115,9 +117,7 @@ void generic_request_handler(struct evhttp_request *req, void *arg)
     struct simplehttp_request *s_req;
     struct evbuffer *evb = evbuffer_new();
     
-    if (debug) {
-        fprintf(stderr, "request for %s from %s\n", req->uri, req->remote_host);
-    }
+    // fprintf(stderr, "request for %s from %s\n", req->uri, req->remote_host);
     
     request_count++;
     
@@ -177,51 +177,33 @@ void simplehttp_set_cb(char *path, void (*cb)(struct evhttp_request *, struct ev
     printf("registering callback for path \"%s\"\n", path);
 }
 
-int simplehttp_main(int argc, char **argv)
+void define_simplehttp_options() {
+    option_define_str("address", OPT_OPTIONAL, "0.0.0.0", NULL, NULL, "address to listen on");
+    option_define_int("port", OPT_OPTIONAL, 8080, NULL, NULL, "port to listen on");
+    option_define_bool("enable_logging", OPT_OPTIONAL, 0, NULL, NULL, "request logging");
+    option_define_bool("daemon", OPT_OPTIONAL, 0, NULL, NULL, "daemonize process");
+    option_define_str("root", OPT_OPTIONAL, NULL, NULL, NULL, "chdir and run from this directory");
+    option_define_str("user", OPT_OPTIONAL, NULL, NULL, NULL, "run as this user");
+    option_define_str("group", OPT_OPTIONAL, NULL, NULL, NULL, "run as this group");
+}
+
+int simplehttp_main()
 {
     uid_t uid = 0;
     gid_t gid = 0;
-    char *address;
-    char *root = NULL;
-    char *garg = NULL;
-    char *uarg = NULL;
-    int daemon = 0;
-    int port, ch, errno;
     pid_t pid, sid;
+    int errno;
     struct evhttp *httpd;
     struct event pipe_ev;
     
-    address = "0.0.0.0";
-    port = 8080;
-    opterr = 0;
-    while ((ch = getopt(argc, argv, "a:p:d:D:r:u:g:V")) != -1) {
-        switch (ch) {
-            case 'a':
-                address = optarg;
-                break;
-            case 'p':
-                port = atoi(optarg);
-                break;
-            case 'd':
-                debug = 1;
-                break;
-            case 'r':
-                root = optarg;
-                break;
-            case 'D':
-                daemon = 1;
-                break;
-            case 'g':
-                garg = optarg;
-                break;
-            case 'u':
-                uarg = optarg;
-                break;
-            case 'V':
-                verbose = 1;
-                break;
-        }
-    }
+    char *address = option_get_str("address");
+    int port = option_get_int("port");
+
+    int daemon = option_get_int("daemon");
+    char *root = option_get_str("root");
+    char *user = option_get_str("user");
+    char *group = option_get_str("group");
+    simplehttp_logging = option_get_int("enable_logging");
     
     if (daemon) {
         pid = fork();
@@ -238,21 +220,21 @@ int simplehttp_main(int argc, char **argv)
         }
     }
     
-    if (uarg != NULL) {
-        uid = get_uid(uarg);
-        gid = get_user_gid(uarg);
+    if (user != NULL) {
+        uid = get_uid(user);
+        gid = get_user_gid(user);
         if (uid < 0) {
-            uid = atoi(uarg);
-            uarg = NULL;
+            uid = atoi(user);
+            user = NULL;
         }
         if (uid == 0) {
             err(1, "invalid user");
         }
     }
-    if (garg != NULL) {
-        gid = get_gid(garg);
+    if (group != NULL) {
+        gid = get_gid(group);
         if (gid < 0) {
-            gid = atoi(garg);
+            gid = atoi(group);
             if (gid == 0) {
                 err(1, "invalid group");
             }
@@ -269,8 +251,8 @@ int simplehttp_main(int argc, char **argv)
     }
     
     if (getuid() == 0) {
-        if (uarg != NULL) {
-            if (initgroups(uarg, (int) gid) != 0) {
+        if (user != NULL) {
+            if (initgroups(user, (int) gid) != 0) {
                 err(1, "initgroups() failed");
             }
         } else {

--- a/simplehttp/simplehttp.h
+++ b/simplehttp/simplehttp.h
@@ -2,6 +2,7 @@
 #define _SIMPLEHTTP_H
 
 #include "queue.h"
+#include "options.h"
 #include <event.h>
 #include <evhttp.h>
 
@@ -31,7 +32,7 @@ struct simplehttp_stats {
 };
 
 void simplehttp_init();
-int simplehttp_main(int argc, char **argv);
+int simplehttp_main();
 void simplehttp_set_cb(char *path, void (*cb)(struct evhttp_request *, struct evbuffer *,void *), void *ctx);
 
 uint64_t simplehttp_request_id(struct evhttp_request *req);
@@ -63,5 +64,6 @@ int get_argument_format(struct evkeyvalq *args);
 int get_int_argument(struct evkeyvalq *args, char *key, int default_value);
 double get_double_argument(struct evkeyvalq *args, char *key, double default_value);
 
+void define_simplehttp_options();
 
 #endif

--- a/simplehttp/testserver.c
+++ b/simplehttp/testserver.c
@@ -1,20 +1,36 @@
 #include <stdio.h>
-#include "simplehttp.h"
+#include "<siplehttp/simplehttp.h>"
+
+#define VERSION "0.1"
 
 void
 cb(struct evhttp_request *req, struct evbuffer *evb,void *ctx)
 {
-    evbuffer_add_printf(evb, "Hello bitches\n%s\n", req->uri);
+    evbuffer_add_printf(evb, "Hello World!\n%s\n", req->uri);
     evhttp_send_reply(req, HTTP_OK, "OK", evb);
 }
+
+int version_cb(int value) {
+    fprintf(stdout, "Version: %s\n", VERSION);
+    return 0;
+}
+
 
 int
 main(int argc, char **argv)
 {
+    define_simplehttp_options();
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
+    
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
+    }
+    
     simplehttp_init();
     simplehttp_set_cb("/ass*", cb, NULL);
     simplehttp_set_cb("/foo*", cb, NULL);
     simplehttp_set_cb("/bar*", cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
     return 0;
 }

--- a/simplehttp/utarray.h
+++ b/simplehttp/utarray.h
@@ -1,0 +1,224 @@
+/*
+Copyright (c) 2008-2010, Troy D. Hanson   http://uthash.sourceforge.net
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* a dynamic array implementation using macros 
+ * see http://uthash.sourceforge.net/utarray
+ */
+#ifndef UTARRAY_H
+#define UTARRAY_H
+
+#define UTARRAY_VERSION 1.9.1
+
+#ifdef __GNUC__
+#define _UNUSED_ __attribute__ ((__unused__)) 
+#else
+#define _UNUSED_ 
+#endif
+
+#include <stddef.h>  /* size_t */
+#include <string.h>  /* memset, etc */
+#include <stdlib.h>  /* exit */
+
+#define oom() exit(-1)
+
+typedef void (ctor_f)(void *dst, const void *src);
+typedef void (dtor_f)(void *elt);
+typedef void (init_f)(void *elt);
+typedef struct {
+    size_t sz;
+    init_f *init;
+    ctor_f *copy;
+    dtor_f *dtor;
+} UT_icd;
+
+typedef struct {
+    unsigned i,n;/* i: index of next available slot, n: num slots */
+    const UT_icd *icd; /* initializer, copy and destructor functions */
+    char *d;     /* n slots of size icd->sz*/
+} UT_array;
+
+#define utarray_init(a,_icd) do {                                             \
+  memset(a,0,sizeof(UT_array));                                               \
+  (a)->icd=_icd;                                                              \
+} while(0)
+
+#define utarray_done(a) do {                                                  \
+  if ((a)->n) {                                                               \
+    if ((a)->icd->dtor) {                                                     \
+      size_t _ut_i;                                                           \
+      for(_ut_i=0; _ut_i < (a)->i; _ut_i++) {                                 \
+        (a)->icd->dtor(utarray_eltptr(a,_ut_i));                              \
+      }                                                                       \
+    }                                                                         \
+    free((a)->d);                                                             \
+  }                                                                           \
+  (a)->n=0;                                                                   \
+} while(0)
+
+#define utarray_new(a,_icd) do {                                              \
+  a=(UT_array*)malloc(sizeof(UT_array));                                      \
+  utarray_init(a,_icd);                                                       \
+} while(0)
+
+#define utarray_free(a) do {                                                  \
+  utarray_done(a);                                                            \
+  free(a);                                                                    \
+} while(0)
+
+#define utarray_reserve(a,by) do {                                            \
+  if (((a)->i+by) > ((a)->n)) {                                               \
+    while(((a)->i+by) > ((a)->n)) { (a)->n = ((a)->n ? (2*(a)->n) : 8); }     \
+    if ( ((a)->d=(char*)realloc((a)->d, (a)->n*(a)->icd->sz)) == NULL) oom(); \
+  }                                                                           \
+} while(0)
+
+#define utarray_push_back(a,p) do {                                           \
+  utarray_reserve(a,1);                                                       \
+  if ((a)->icd->copy) { (a)->icd->copy( _utarray_eltptr(a,(a)->i++), p); }    \
+  else { memcpy(_utarray_eltptr(a,(a)->i++), p, (a)->icd->sz); };             \
+} while(0)
+
+#define utarray_pop_back(a) do {                                              \
+  if ((a)->icd->dtor) { (a)->icd->dtor( _utarray_eltptr(a,--((a)->i))); }     \
+  else { (a)->i--; }                                                          \
+} while(0)
+
+#define utarray_extend_back(a) do {                                           \
+  utarray_reserve(a,1);                                                       \
+  if ((a)->icd->init) { (a)->icd->init(_utarray_eltptr(a,(a)->i)); }          \
+  else { memset(_utarray_eltptr(a,(a)->i),0,(a)->icd->sz); }                  \
+  (a)->i++;                                                                   \
+} while(0)
+
+#define utarray_len(a) ((a)->i)
+
+#define utarray_eltptr(a,j) (((j) < (a)->i) ? _utarray_eltptr(a,j) : NULL)
+#define _utarray_eltptr(a,j) ((char*)((a)->d + ((a)->icd->sz*(j) )))
+
+#define utarray_insert(a,p,j) do {                                            \
+  utarray_reserve(a,1);                                                       \
+  if (j > (a)->i) break;                                                      \
+  if ((j) < (a)->i) {                                                         \
+    memmove( _utarray_eltptr(a,(j)+1), _utarray_eltptr(a,j),                  \
+             ((a)->i - (j))*((a)->icd->sz));                                  \
+  }                                                                           \
+  if ((a)->icd->copy) { (a)->icd->copy( _utarray_eltptr(a,j), p); }           \
+  else { memcpy(_utarray_eltptr(a,j), p, (a)->icd->sz); };                    \
+  (a)->i++;                                                                   \
+} while(0)
+
+#define utarray_inserta(a,w,j) do {                                           \
+  if (utarray_len(w) == 0) break;                                             \
+  if (j > (a)->i) break;                                                      \
+  utarray_reserve(a,utarray_len(w));                                          \
+  if ((j) < (a)->i) {                                                         \
+    memmove(_utarray_eltptr(a,(j)+utarray_len(w)),                            \
+            _utarray_eltptr(a,j),                                             \
+            ((a)->i - (j))*((a)->icd->sz));                                   \
+  }                                                                           \
+  if (a->icd->copy) {                                                         \
+    size_t _ut_i;                                                             \
+    for(_ut_i=0;_ut_i<(w)->i;_ut_i++) {                                       \
+      (a)->icd->copy(_utarray_eltptr(a,j+_ut_i), _utarray_eltptr(w,_ut_i));   \
+    }                                                                         \
+  } else {                                                                    \
+    memcpy(_utarray_eltptr(a,j), _utarray_eltptr(w,0),                        \
+           utarray_len(w)*((a)->icd->sz));                                    \
+  }                                                                           \
+  (a)->i += utarray_len(w);                                                   \
+} while(0)
+
+#define utarray_resize(dst,num) do {                                          \
+  size_t _ut_i;                                                               \
+  if (dst->i > (size_t)(num)) {                                               \
+    if ((dst)->icd->dtor) {                                                   \
+      for(_ut_i=num; _ut_i < dst->i; _ut_i++) {                               \
+        (dst)->icd->dtor(utarray_eltptr(dst,_ut_i));                          \
+      }                                                                       \
+    }                                                                         \
+  } else if (dst->i < (size_t)(num)) {                                        \
+    utarray_reserve(dst,num-dst->i);                                          \
+    if ((dst)->icd->init) {                                                   \
+      for(_ut_i=dst->i; _ut_i < num; _ut_i++) {                               \
+        (dst)->icd->init(utarray_eltptr(dst,_ut_i));                          \
+      }                                                                       \
+    } else {                                                                  \
+      memset(_utarray_eltptr(dst,dst->i),0,(dst)->icd->sz*(num-dst->i));      \
+    }                                                                         \
+  }                                                                           \
+  dst->i = num;                                                               \
+} while(0)
+
+#define utarray_concat(dst,src) do {                                          \
+  utarray_inserta(dst,src,utarray_len(dst));                                  \
+} while(0)
+
+#define utarray_erase(a,pos,len) do {                                         \
+  if ((a)->icd->dtor) {                                                       \
+    size_t _ut_i;                                                             \
+    for(_ut_i=0; _ut_i < len; _ut_i++) {                                      \
+      (a)->icd->dtor(utarray_eltptr(a,pos+_ut_i));                            \
+    }                                                                         \
+  }                                                                           \
+  if ((a)->i > (pos+len)) {                                                   \
+    memmove( _utarray_eltptr(a,pos), _utarray_eltptr(a,pos+len),              \
+            ((a->i)-(pos+len))*((a)->icd->sz));                               \
+  }                                                                           \
+  (a)->i -= (len);                                                            \
+} while(0)
+
+#define utarray_clear(a) do {                                                 \
+  if ((a)->i > 0) {                                                           \
+    if ((a)->icd->dtor) {                                                     \
+      size_t _ut_i;                                                           \
+      for(_ut_i=0; _ut_i < (a)->i; _ut_i++) {                                 \
+        (a)->icd->dtor(utarray_eltptr(a,_ut_i));                              \
+      }                                                                       \
+    }                                                                         \
+    (a)->i = 0;                                                               \
+  }                                                                           \
+} while(0)
+
+#define utarray_sort(a,cmp) do {                                              \
+  qsort((a)->d, (a)->i, (a)->icd->sz, cmp);                                   \
+} while(0)
+
+#define utarray_front(a) (((a)->i) ? (_utarray_eltptr(a,0)) : NULL)
+#define utarray_next(a,e) (((e)==NULL) ? utarray_front(a) : ((((a)->i) > (utarray_eltidx(a,e)+1)) ? _utarray_eltptr(a,utarray_eltidx(a,e)+1) : NULL))
+#define utarray_back(a) (((a)->i) ? (_utarray_eltptr(a,(a)->i-1)) : NULL)
+#define utarray_eltidx(a,e) (((char*)(e) >= (char*)((a)->d)) ? (((char*)(e) - (char*)((a)->d))/(a)->icd->sz) : -1)
+
+/* last we pre-define a few icd for common utarrays of ints and strings */
+static void utarray_str_cpy(void *dst, const void *src) {
+  char **_src = (char**)src, **_dst = (char**)dst;
+  *_dst = (*_src == NULL) ? NULL : strdup(*_src);
+}
+static void utarray_str_dtor(void *elt) {
+  char **eltc = (char**)elt;
+  if (*eltc) free(*eltc);
+}
+static const UT_icd ut_str_icd _UNUSED_ = {sizeof(char*),NULL,utarray_str_cpy,utarray_str_dtor};
+static const UT_icd ut_int_icd _UNUSED_ = {sizeof(int),NULL,NULL,NULL};
+
+
+#endif /* UTARRAY_H */

--- a/simplehttp/uthash.h
+++ b/simplehttp/uthash.h
@@ -1,0 +1,972 @@
+/*
+Copyright (c) 2003-2010, Troy D. Hanson     http://uthash.sourceforge.net
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTHASH_H
+#define UTHASH_H 
+
+#include <string.h>   /* memcmp,strlen */
+#include <stddef.h>   /* ptrdiff_t */
+
+/* These macros use decltype or the earlier __typeof GNU extension.
+   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   when compiling c++ source) this code uses whatever method is needed
+   or, for VS2008 where neither is available, uses casting workarounds. */
+#ifdef _MSC_VER         /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#define DECLTYPE(x) (decltype(x))
+#else                   /* VS2008 or older (or VS2010 in C mode) */
+#define NO_DECLTYPE
+#define DECLTYPE(x)
+#endif
+#else                   /* GNU, Sun and other compilers */
+#define DECLTYPE(x) (__typeof(x))
+#endif
+
+#ifdef NO_DECLTYPE
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  char **_da_dst = (char**)(&(dst));                                             \
+  *_da_dst = (char*)(src);                                                       \
+} while(0)
+#else 
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  (dst) = DECLTYPE(dst)(src);                                                    \
+} while(0)
+#endif
+
+/* a number of the hash function use uint32_t which isn't defined on win32 */
+#ifdef _MSC_VER
+typedef unsigned int uint32_t;
+#else
+#include <inttypes.h>   /* uint32_t */
+#endif
+
+#define UTHASH_VERSION 1.9.3
+
+#define uthash_fatal(msg) exit(-1)        /* fatal error (out of memory,etc) */
+#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+
+#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+
+/* initial number of buckets */
+#define HASH_INITIAL_NUM_BUCKETS 32      /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS_LOG2 5  /* lg2 of initial number of buckets */
+#define HASH_BKT_CAPACITY_THRESH 10      /* expand when bucket count reaches */
+
+/* calculate the element whose hash handle address is hhe */
+#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+
+#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
+do {                                                                             \
+  unsigned _hf_bkt,_hf_hashv;                                                    \
+  out=NULL;                                                                      \
+  if (head) {                                                                    \
+     HASH_FCN(keyptr,keylen, (head)->hh.tbl->num_buckets, _hf_hashv, _hf_bkt);   \
+     if (HASH_BLOOM_TEST((head)->hh.tbl, _hf_hashv)) {                           \
+       HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ],  \
+                        keyptr,keylen,out);                                      \
+     }                                                                           \
+  }                                                                              \
+} while (0)
+
+#ifdef HASH_BLOOM
+#define HASH_BLOOM_BITLEN (1ULL << HASH_BLOOM)
+#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8) + ((HASH_BLOOM_BITLEN%8) ? 1:0)
+#define HASH_BLOOM_MAKE(tbl)                                                     \
+do {                                                                             \
+  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
+  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
+  if (!((tbl)->bloom_bv))  { uthash_fatal( "out of memory"); }                   \
+  memset((tbl)->bloom_bv, 0, HASH_BLOOM_BYTELEN);                                \
+  (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                       \
+} while (0);
+
+#define HASH_BLOOM_FREE(tbl)                                                     \
+do {                                                                             \
+  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
+} while (0);
+
+#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8] |= (1U << ((idx)%8)))
+#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8] & (1U << ((idx)%8)))
+
+#define HASH_BLOOM_ADD(tbl,hashv)                                                \
+  HASH_BLOOM_BITSET((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
+
+#define HASH_BLOOM_TEST(tbl,hashv)                                               \
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
+
+#else
+#define HASH_BLOOM_MAKE(tbl) 
+#define HASH_BLOOM_FREE(tbl) 
+#define HASH_BLOOM_ADD(tbl,hashv) 
+#define HASH_BLOOM_TEST(tbl,hashv) (1)
+#endif
+
+#define HASH_MAKE_TABLE(hh,head)                                                 \
+do {                                                                             \
+  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(                                \
+                  sizeof(UT_hash_table));                                        \
+  if (!((head)->hh.tbl))  { uthash_fatal( "out of memory"); }                    \
+  memset((head)->hh.tbl, 0, sizeof(UT_hash_table));                              \
+  (head)->hh.tbl->tail = &((head)->hh);                                          \
+  (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                        \
+  (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;              \
+  (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                    \
+  (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                      \
+          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
+  if (! (head)->hh.tbl->buckets) { uthash_fatal( "out of memory"); }             \
+  memset((head)->hh.tbl->buckets, 0,                                             \
+          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
+  HASH_BLOOM_MAKE((head)->hh.tbl);                                               \
+  (head)->hh.tbl->signature = HASH_SIGNATURE;                                    \
+} while(0)
+
+#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
+        HASH_ADD_KEYPTR(hh,head,&add->fieldname,keylen_in,add)
+ 
+#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
+do {                                                                             \
+ unsigned _ha_bkt;                                                               \
+ (add)->hh.next = NULL;                                                          \
+ (add)->hh.key = (char*)keyptr;                                                  \
+ (add)->hh.keylen = keylen_in;                                                   \
+ if (!(head)) {                                                                  \
+    head = (add);                                                                \
+    (head)->hh.prev = NULL;                                                      \
+    HASH_MAKE_TABLE(hh,head);                                                    \
+ } else {                                                                        \
+    (head)->hh.tbl->tail->next = (add);                                          \
+    (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);         \
+    (head)->hh.tbl->tail = &((add)->hh);                                         \
+ }                                                                               \
+ (head)->hh.tbl->num_items++;                                                    \
+ (add)->hh.tbl = (head)->hh.tbl;                                                 \
+ HASH_FCN(keyptr,keylen_in, (head)->hh.tbl->num_buckets,                         \
+         (add)->hh.hashv, _ha_bkt);                                              \
+ HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt],&(add)->hh);                   \
+ HASH_BLOOM_ADD((head)->hh.tbl,(add)->hh.hashv);                                 \
+ HASH_EMIT_KEY(hh,head,keyptr,keylen_in);                                        \
+ HASH_FSCK(hh,head);                                                             \
+} while(0)
+
+#define HASH_TO_BKT( hashv, num_bkts, bkt )                                      \
+do {                                                                             \
+  bkt = ((hashv) & ((num_bkts) - 1));                                            \
+} while(0)
+
+/* delete "delptr" from the hash table.
+ * "the usual" patch-up process for the app-order doubly-linked-list.
+ * The use of _hd_hh_del below deserves special explanation.
+ * These used to be expressed using (delptr) but that led to a bug
+ * if someone used the same symbol for the head and deletee, like
+ *  HASH_DELETE(hh,users,users);
+ * We want that to work, but by changing the head (users) below
+ * we were forfeiting our ability to further refer to the deletee (users)
+ * in the patch-up process. Solution: use scratch space to
+ * copy the deletee pointer, then the latter references are via that
+ * scratch pointer rather than through the repointed (users) symbol.
+ */
+#define HASH_DELETE(hh,head,delptr)                                              \
+do {                                                                             \
+    unsigned _hd_bkt;                                                            \
+    struct UT_hash_handle *_hd_hh_del;                                           \
+    if ( ((delptr)->hh.prev == NULL) && ((delptr)->hh.next == NULL) )  {         \
+        uthash_free((head)->hh.tbl->buckets,                                     \
+                    (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
+        HASH_BLOOM_FREE((head)->hh.tbl);                                         \
+        uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                      \
+        head = NULL;                                                             \
+    } else {                                                                     \
+        _hd_hh_del = &((delptr)->hh);                                            \
+        if ((delptr) == ELMT_FROM_HH((head)->hh.tbl,(head)->hh.tbl->tail)) {     \
+            (head)->hh.tbl->tail =                                               \
+                (UT_hash_handle*)((char*)((delptr)->hh.prev) +                   \
+                (head)->hh.tbl->hho);                                            \
+        }                                                                        \
+        if ((delptr)->hh.prev) {                                                 \
+            ((UT_hash_handle*)((char*)((delptr)->hh.prev) +                      \
+                    (head)->hh.tbl->hho))->next = (delptr)->hh.next;             \
+        } else {                                                                 \
+            DECLTYPE_ASSIGN(head,(delptr)->hh.next);                             \
+        }                                                                        \
+        if (_hd_hh_del->next) {                                                  \
+            ((UT_hash_handle*)((char*)_hd_hh_del->next +                         \
+                    (head)->hh.tbl->hho))->prev =                                \
+                    _hd_hh_del->prev;                                            \
+        }                                                                        \
+        HASH_TO_BKT( _hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);   \
+        HASH_DEL_IN_BKT(hh,(head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);        \
+        (head)->hh.tbl->num_items--;                                             \
+    }                                                                            \
+    HASH_FSCK(hh,head);                                                          \
+} while (0)
+
+
+/* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
+#define HASH_FIND_STR(head,findstr,out)                                          \
+    HASH_FIND(hh,head,findstr,strlen(findstr),out)
+#define HASH_ADD_STR(head,strfield,add)                                          \
+    HASH_ADD(hh,head,strfield,strlen(add->strfield),add)
+#define HASH_FIND_INT(head,findint,out)                                          \
+    HASH_FIND(hh,head,findint,sizeof(int),out)
+#define HASH_ADD_INT(head,intfield,add)                                          \
+    HASH_ADD(hh,head,intfield,sizeof(int),add)
+#define HASH_FIND_PTR(head,findptr,out)                                          \
+    HASH_FIND(hh,head,findptr,sizeof(void *),out)
+#define HASH_ADD_PTR(head,ptrfield,add)                                          \
+    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
+#define HASH_DEL(head,delptr)                                                    \
+    HASH_DELETE(hh,head,delptr)
+
+/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
+ * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+ */
+#ifdef HASH_DEBUG
+#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
+#define HASH_FSCK(hh,head)                                                       \
+do {                                                                             \
+    unsigned _bkt_i;                                                             \
+    unsigned _count, _bkt_count;                                                 \
+    char *_prev;                                                                 \
+    struct UT_hash_handle *_thh;                                                 \
+    if (head) {                                                                  \
+        _count = 0;                                                              \
+        for( _bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; _bkt_i++) {       \
+            _bkt_count = 0;                                                      \
+            _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                      \
+            _prev = NULL;                                                        \
+            while (_thh) {                                                       \
+               if (_prev != (char*)(_thh->hh_prev)) {                            \
+                   HASH_OOPS("invalid hh_prev %p, actual %p\n",                  \
+                    _thh->hh_prev, _prev );                                      \
+               }                                                                 \
+               _bkt_count++;                                                     \
+               _prev = (char*)(_thh);                                            \
+               _thh = _thh->hh_next;                                             \
+            }                                                                    \
+            _count += _bkt_count;                                                \
+            if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {          \
+               HASH_OOPS("invalid bucket count %d, actual %d\n",                 \
+                (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);              \
+            }                                                                    \
+        }                                                                        \
+        if (_count != (head)->hh.tbl->num_items) {                               \
+            HASH_OOPS("invalid hh item count %d, actual %d\n",                   \
+                (head)->hh.tbl->num_items, _count );                             \
+        }                                                                        \
+        /* traverse hh in app order; check next/prev integrity, count */         \
+        _count = 0;                                                              \
+        _prev = NULL;                                                            \
+        _thh =  &(head)->hh;                                                     \
+        while (_thh) {                                                           \
+           _count++;                                                             \
+           if (_prev !=(char*)(_thh->prev)) {                                    \
+              HASH_OOPS("invalid prev %p, actual %p\n",                          \
+                    _thh->prev, _prev );                                         \
+           }                                                                     \
+           _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                    \
+           _thh = ( _thh->next ?  (UT_hash_handle*)((char*)(_thh->next) +        \
+                                  (head)->hh.tbl->hho) : NULL );                 \
+        }                                                                        \
+        if (_count != (head)->hh.tbl->num_items) {                               \
+            HASH_OOPS("invalid app item count %d, actual %d\n",                  \
+                (head)->hh.tbl->num_items, _count );                             \
+        }                                                                        \
+    }                                                                            \
+} while (0)
+#else
+#define HASH_FSCK(hh,head) 
+#endif
+
+/* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to 
+ * the descriptor to which this macro is defined for tuning the hash function.
+ * The app can #include <unistd.h> to get the prototype for write(2). */
+#ifdef HASH_EMIT_KEYS
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
+do {                                                                             \
+    unsigned _klen = fieldlen;                                                   \
+    write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                \
+    write(HASH_EMIT_KEYS, keyptr, fieldlen);                                     \
+} while (0)
+#else 
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                    
+#endif
+
+/* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
+#ifdef HASH_FUNCTION 
+#define HASH_FCN HASH_FUNCTION
+#else
+#define HASH_FCN HASH_JEN
+#endif
+
+/* The Bernstein hash function, used in Perl prior to v5.6 */
+#define HASH_BER(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _hb_keylen=keylen;                                                    \
+  char *_hb_key=(char*)(key);                                                    \
+  (hashv) = 0;                                                                   \
+  while (_hb_keylen--)  { (hashv) = ((hashv) * 33) + *_hb_key++; }               \
+  bkt = (hashv) & (num_bkts-1);                                                  \
+} while (0)
+
+
+/* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at 
+ * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
+#define HASH_SAX(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _sx_i;                                                                \
+  char *_hs_key=(char*)(key);                                                    \
+  hashv = 0;                                                                     \
+  for(_sx_i=0; _sx_i < keylen; _sx_i++)                                          \
+      hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                     \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while (0)
+
+#define HASH_FNV(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _fn_i;                                                                \
+  char *_hf_key=(char*)(key);                                                    \
+  hashv = 2166136261UL;                                                          \
+  for(_fn_i=0; _fn_i < keylen; _fn_i++)                                          \
+      hashv = (hashv * 16777619) ^ _hf_key[_fn_i];                               \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0);
+ 
+#define HASH_OAT(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _ho_i;                                                                \
+  char *_ho_key=(char*)(key);                                                    \
+  hashv = 0;                                                                     \
+  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
+      hashv += _ho_key[_ho_i];                                                   \
+      hashv += (hashv << 10);                                                    \
+      hashv ^= (hashv >> 6);                                                     \
+  }                                                                              \
+  hashv += (hashv << 3);                                                         \
+  hashv ^= (hashv >> 11);                                                        \
+  hashv += (hashv << 15);                                                        \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+
+#define HASH_JEN_MIX(a,b,c)                                                      \
+do {                                                                             \
+  a -= b; a -= c; a ^= ( c >> 13 );                                              \
+  b -= c; b -= a; b ^= ( a << 8 );                                               \
+  c -= a; c -= b; c ^= ( b >> 13 );                                              \
+  a -= b; a -= c; a ^= ( c >> 12 );                                              \
+  b -= c; b -= a; b ^= ( a << 16 );                                              \
+  c -= a; c -= b; c ^= ( b >> 5 );                                               \
+  a -= b; a -= c; a ^= ( c >> 3 );                                               \
+  b -= c; b -= a; b ^= ( a << 10 );                                              \
+  c -= a; c -= b; c ^= ( b >> 15 );                                              \
+} while (0)
+
+#define HASH_JEN(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _hj_i,_hj_j,_hj_k;                                                    \
+  char *_hj_key=(char*)(key);                                                    \
+  hashv = 0xfeedbeef;                                                            \
+  _hj_i = _hj_j = 0x9e3779b9;                                                    \
+  _hj_k = keylen;                                                                \
+  while (_hj_k >= 12) {                                                          \
+    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
+        + ( (unsigned)_hj_key[2] << 16 )                                         \
+        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
+    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
+        + ( (unsigned)_hj_key[6] << 16 )                                         \
+        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
+    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
+        + ( (unsigned)_hj_key[10] << 16 )                                        \
+        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
+                                                                                 \
+     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
+                                                                                 \
+     _hj_key += 12;                                                              \
+     _hj_k -= 12;                                                                \
+  }                                                                              \
+  hashv += keylen;                                                               \
+  switch ( _hj_k ) {                                                             \
+     case 11: hashv += ( (unsigned)_hj_key[10] << 24 );                          \
+     case 10: hashv += ( (unsigned)_hj_key[9] << 16 );                           \
+     case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );                            \
+     case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );                           \
+     case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );                           \
+     case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );                            \
+     case 5:  _hj_j += _hj_key[4];                                               \
+     case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );                           \
+     case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );                           \
+     case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );                            \
+     case 1:  _hj_i += _hj_key[0];                                               \
+  }                                                                              \
+  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+
+/* The Paul Hsieh hash function */
+#undef get16bits
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
+  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
+#define get16bits(d) (*((const uint16_t *) (d)))
+#endif
+
+#if !defined (get16bits)
+#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
+                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#endif
+#define HASH_SFH(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  char *_sfh_key=(char*)(key);                                                   \
+  uint32_t _sfh_tmp, _sfh_len = keylen;                                          \
+                                                                                 \
+  int _sfh_rem = _sfh_len & 3;                                                   \
+  _sfh_len >>= 2;                                                                \
+  hashv = 0xcafebabe;                                                            \
+                                                                                 \
+  /* Main loop */                                                                \
+  for (;_sfh_len > 0; _sfh_len--) {                                              \
+    hashv    += get16bits (_sfh_key);                                            \
+    _sfh_tmp       = (get16bits (_sfh_key+2) << 11) ^ hashv;                     \
+    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
+    _sfh_key += 2*sizeof (uint16_t);                                             \
+    hashv    += hashv >> 11;                                                     \
+  }                                                                              \
+                                                                                 \
+  /* Handle end cases */                                                         \
+  switch (_sfh_rem) {                                                            \
+    case 3: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 16;                                                \
+            hashv ^= _sfh_key[sizeof (uint16_t)] << 18;                          \
+            hashv += hashv >> 11;                                                \
+            break;                                                               \
+    case 2: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 11;                                                \
+            hashv += hashv >> 17;                                                \
+            break;                                                               \
+    case 1: hashv += *_sfh_key;                                                  \
+            hashv ^= hashv << 10;                                                \
+            hashv += hashv >> 1;                                                 \
+  }                                                                              \
+                                                                                 \
+    /* Force "avalanching" of final 127 bits */                                  \
+    hashv ^= hashv << 3;                                                         \
+    hashv += hashv >> 5;                                                         \
+    hashv ^= hashv << 4;                                                         \
+    hashv += hashv >> 17;                                                        \
+    hashv ^= hashv << 25;                                                        \
+    hashv += hashv >> 6;                                                         \
+    bkt = hashv & (num_bkts-1);                                                  \
+} while(0);
+
+#ifdef HASH_USING_NO_STRICT_ALIASING
+/* The MurmurHash exploits some CPU's (e.g. x86) tolerance for unaligned reads.
+ * For other types of CPU's (e.g. Sparc) an unaligned read causes a bus error.
+ * So MurmurHash comes in two versions, the faster unaligned one and the slower
+ * aligned one. We only use the faster one on CPU's where we know it's safe. 
+ *
+ * Note the preprocessor built-in defines can be emitted using:
+ *
+ *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
+ *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
+ */
+#if (defined(__i386__) || defined(__x86_64__)) 
+#define HASH_MUR HASH_MUR_UNALIGNED
+#else
+#define HASH_MUR HASH_MUR_ALIGNED
+#endif
+
+/* Appleby's MurmurHash fast version for unaligned-tolerant archs like i386 */
+#define HASH_MUR_UNALIGNED(key,keylen,num_bkts,hashv,bkt)                        \
+do {                                                                             \
+  const unsigned int _mur_m = 0x5bd1e995;                                        \
+  const int _mur_r = 24;                                                         \
+  hashv = 0xcafebabe ^ keylen;                                                   \
+  char *_mur_key = (char *)(key);                                                \
+  uint32_t _mur_tmp, _mur_len = keylen;                                          \
+                                                                                 \
+  for (;_mur_len >= 4; _mur_len-=4) {                                            \
+    _mur_tmp = *(uint32_t *)_mur_key;                                            \
+    _mur_tmp *= _mur_m;                                                          \
+    _mur_tmp ^= _mur_tmp >> _mur_r;                                              \
+    _mur_tmp *= _mur_m;                                                          \
+    hashv *= _mur_m;                                                             \
+    hashv ^= _mur_tmp;                                                           \
+    _mur_key += 4;                                                               \
+  }                                                                              \
+                                                                                 \
+  switch(_mur_len)                                                               \
+  {                                                                              \
+    case 3: hashv ^= _mur_key[2] << 16;                                          \
+    case 2: hashv ^= _mur_key[1] << 8;                                           \
+    case 1: hashv ^= _mur_key[0];                                                \
+            hashv *= _mur_m;                                                     \
+  };                                                                             \
+                                                                                 \
+  hashv ^= hashv >> 13;                                                          \
+  hashv *= _mur_m;                                                               \
+  hashv ^= hashv >> 15;                                                          \
+                                                                                 \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+
+/* Appleby's MurmurHash version for alignment-sensitive archs like Sparc */
+#define HASH_MUR_ALIGNED(key,keylen,num_bkts,hashv,bkt)                          \
+do {                                                                             \
+  const unsigned int _mur_m = 0x5bd1e995;                                        \
+  const int _mur_r = 24;                                                         \
+  hashv = 0xcafebabe ^ (keylen);                                                 \
+  char *_mur_key = (char *)(key);                                                \
+  uint32_t _mur_len = keylen;                                                    \
+  int _mur_align = (int)_mur_key & 3;                                            \
+                                                                                 \
+  if (_mur_align && (_mur_len >= 4)) {                                           \
+    unsigned _mur_t = 0, _mur_d = 0;                                             \
+    switch(_mur_align) {                                                         \
+      case 1: _mur_t |= _mur_key[2] << 16;                                       \
+      case 2: _mur_t |= _mur_key[1] << 8;                                        \
+      case 3: _mur_t |= _mur_key[0];                                             \
+    }                                                                            \
+    _mur_t <<= (8 * _mur_align);                                                 \
+    _mur_key += 4-_mur_align;                                                    \
+    _mur_len -= 4-_mur_align;                                                    \
+    int _mur_sl = 8 * (4-_mur_align);                                            \
+    int _mur_sr = 8 * _mur_align;                                                \
+                                                                                 \
+    for (;_mur_len >= 4; _mur_len-=4) {                                          \
+      _mur_d = *(unsigned *)_mur_key;                                            \
+      _mur_t = (_mur_t >> _mur_sr) | (_mur_d << _mur_sl);                        \
+      unsigned _mur_k = _mur_t;                                                  \
+      _mur_k *= _mur_m;                                                          \
+      _mur_k ^= _mur_k >> _mur_r;                                                \
+      _mur_k *= _mur_m;                                                          \
+      hashv *= _mur_m;                                                           \
+      hashv ^= _mur_k;                                                           \
+      _mur_t = _mur_d;                                                           \
+      _mur_key += 4;                                                             \
+    }                                                                            \
+    _mur_d = 0;                                                                  \
+    if(_mur_len >= _mur_align) {                                                 \
+      switch(_mur_align) {                                                       \
+        case 3: _mur_d |= _mur_key[2] << 16;                                     \
+        case 2: _mur_d |= _mur_key[1] << 8;                                      \
+        case 1: _mur_d |= _mur_key[0];                                           \
+      }                                                                          \
+      unsigned _mur_k = (_mur_t >> _mur_sr) | (_mur_d << _mur_sl);               \
+      _mur_k *= _mur_m;                                                          \
+      _mur_k ^= _mur_k >> _mur_r;                                                \
+      _mur_k *= _mur_m;                                                          \
+      hashv *= _mur_m;                                                           \
+      hashv ^= _mur_k;                                                           \
+      _mur_k += _mur_align;                                                      \
+      _mur_len -= _mur_align;                                                    \
+                                                                                 \
+      switch(_mur_len)                                                           \
+      {                                                                          \
+        case 3: hashv ^= _mur_key[2] << 16;                                      \
+        case 2: hashv ^= _mur_key[1] << 8;                                       \
+        case 1: hashv ^= _mur_key[0];                                            \
+                hashv *= _mur_m;                                                 \
+      }                                                                          \
+    } else {                                                                     \
+      switch(_mur_len)                                                           \
+      {                                                                          \
+        case 3: _mur_d ^= _mur_key[2] << 16;                                     \
+        case 2: _mur_d ^= _mur_key[1] << 8;                                      \
+        case 1: _mur_d ^= _mur_key[0];                                           \
+        case 0: hashv ^= (_mur_t >> _mur_sr) | (_mur_d << _mur_sl);              \
+        hashv *= _mur_m;                                                         \
+      }                                                                          \
+    }                                                                            \
+                                                                                 \
+    hashv ^= hashv >> 13;                                                        \
+    hashv *= _mur_m;                                                             \
+    hashv ^= hashv >> 15;                                                        \
+  } else {                                                                       \
+    for (;_mur_len >= 4; _mur_len-=4) {                                          \
+      unsigned _mur_k = *(unsigned*)_mur_key;                                    \
+      _mur_k *= _mur_m;                                                          \
+      _mur_k ^= _mur_k >> _mur_r;                                                \
+      _mur_k *= _mur_m;                                                          \
+      hashv *= _mur_m;                                                           \
+      hashv ^= _mur_k;                                                           \
+      _mur_key += 4;                                                             \
+    }                                                                            \
+    switch(_mur_len)                                                             \
+    {                                                                            \
+      case 3: hashv ^= _mur_key[2] << 16;                                        \
+      case 2: hashv ^= _mur_key[1] << 8;                                         \
+      case 1: hashv ^= _mur_key[0];                                              \
+      hashv *= _mur_m;                                                           \
+    }                                                                            \
+                                                                                 \
+    hashv ^= hashv >> 13;                                                        \
+    hashv *= _mur_m;                                                             \
+    hashv ^= hashv >> 15;                                                        \
+  }                                                                              \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+#endif  /* HASH_USING_NO_STRICT_ALIASING */
+
+/* key comparison function; return 0 if keys equal */
+#define HASH_KEYCMP(a,b,len) memcmp(a,b,len) 
+
+/* iterate over items in a known bucket to find desired item */
+#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,out)                       \
+do {                                                                             \
+ if (head.hh_head) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,head.hh_head));          \
+ else out=NULL;                                                                  \
+ while (out) {                                                                   \
+    if (out->hh.keylen == keylen_in) {                                           \
+        if ((HASH_KEYCMP(out->hh.key,keyptr,keylen_in)) == 0) break;             \
+    }                                                                            \
+    if (out->hh.hh_next) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,out->hh.hh_next)); \
+    else out = NULL;                                                             \
+ }                                                                               \
+} while(0)
+
+/* add an item to a bucket  */
+#define HASH_ADD_TO_BKT(head,addhh)                                              \
+do {                                                                             \
+ head.count++;                                                                   \
+ (addhh)->hh_next = head.hh_head;                                                \
+ (addhh)->hh_prev = NULL;                                                        \
+ if (head.hh_head) { (head).hh_head->hh_prev = (addhh); }                        \
+ (head).hh_head=addhh;                                                           \
+ if (head.count >= ((head.expand_mult+1) * HASH_BKT_CAPACITY_THRESH)             \
+     && (addhh)->tbl->noexpand != 1) {                                           \
+       HASH_EXPAND_BUCKETS((addhh)->tbl);                                        \
+ }                                                                               \
+} while(0)
+
+/* remove an item from a given bucket */
+#define HASH_DEL_IN_BKT(hh,head,hh_del)                                          \
+    (head).count--;                                                              \
+    if ((head).hh_head == hh_del) {                                              \
+      (head).hh_head = hh_del->hh_next;                                          \
+    }                                                                            \
+    if (hh_del->hh_prev) {                                                       \
+        hh_del->hh_prev->hh_next = hh_del->hh_next;                              \
+    }                                                                            \
+    if (hh_del->hh_next) {                                                       \
+        hh_del->hh_next->hh_prev = hh_del->hh_prev;                              \
+    }                                                                
+
+/* Bucket expansion has the effect of doubling the number of buckets
+ * and redistributing the items into the new buckets. Ideally the
+ * items will distribute more or less evenly into the new buckets
+ * (the extent to which this is true is a measure of the quality of
+ * the hash function as it applies to the key domain). 
+ * 
+ * With the items distributed into more buckets, the chain length
+ * (item count) in each bucket is reduced. Thus by expanding buckets
+ * the hash keeps a bound on the chain length. This bounded chain 
+ * length is the essence of how a hash provides constant time lookup.
+ * 
+ * The calculation of tbl->ideal_chain_maxlen below deserves some
+ * explanation. First, keep in mind that we're calculating the ideal
+ * maximum chain length based on the *new* (doubled) bucket count.
+ * In fractions this is just n/b (n=number of items,b=new num buckets).
+ * Since the ideal chain length is an integer, we want to calculate 
+ * ceil(n/b). We don't depend on floating point arithmetic in this
+ * hash, so to calculate ceil(n/b) with integers we could write
+ * 
+ *      ceil(n/b) = (n/b) + ((n%b)?1:0)
+ * 
+ * and in fact a previous version of this hash did just that.
+ * But now we have improved things a bit by recognizing that b is
+ * always a power of two. We keep its base 2 log handy (call it lb),
+ * so now we can write this with a bit shift and logical AND:
+ * 
+ *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
+ * 
+ */
+#define HASH_EXPAND_BUCKETS(tbl)                                                 \
+do {                                                                             \
+    unsigned _he_bkt;                                                            \
+    unsigned _he_bkt_i;                                                          \
+    struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                 \
+    UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                \
+    _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                            \
+             2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));              \
+    if (!_he_new_buckets) { uthash_fatal( "out of memory"); }                    \
+    memset(_he_new_buckets, 0,                                                   \
+            2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));               \
+    tbl->ideal_chain_maxlen =                                                    \
+       (tbl->num_items >> (tbl->log2_num_buckets+1)) +                           \
+       ((tbl->num_items & ((tbl->num_buckets*2)-1)) ? 1 : 0);                    \
+    tbl->nonideal_items = 0;                                                     \
+    for(_he_bkt_i = 0; _he_bkt_i < tbl->num_buckets; _he_bkt_i++)                \
+    {                                                                            \
+        _he_thh = tbl->buckets[ _he_bkt_i ].hh_head;                             \
+        while (_he_thh) {                                                        \
+           _he_hh_nxt = _he_thh->hh_next;                                        \
+           HASH_TO_BKT( _he_thh->hashv, tbl->num_buckets*2, _he_bkt);            \
+           _he_newbkt = &(_he_new_buckets[ _he_bkt ]);                           \
+           if (++(_he_newbkt->count) > tbl->ideal_chain_maxlen) {                \
+             tbl->nonideal_items++;                                              \
+             _he_newbkt->expand_mult = _he_newbkt->count /                       \
+                                        tbl->ideal_chain_maxlen;                 \
+           }                                                                     \
+           _he_thh->hh_prev = NULL;                                              \
+           _he_thh->hh_next = _he_newbkt->hh_head;                               \
+           if (_he_newbkt->hh_head) _he_newbkt->hh_head->hh_prev =               \
+                _he_thh;                                                         \
+           _he_newbkt->hh_head = _he_thh;                                        \
+           _he_thh = _he_hh_nxt;                                                 \
+        }                                                                        \
+    }                                                                            \
+    uthash_free( tbl->buckets, tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
+    tbl->num_buckets *= 2;                                                       \
+    tbl->log2_num_buckets++;                                                     \
+    tbl->buckets = _he_new_buckets;                                              \
+    tbl->ineff_expands = (tbl->nonideal_items > (tbl->num_items >> 1)) ?         \
+        (tbl->ineff_expands+1) : 0;                                              \
+    if (tbl->ineff_expands > 1) {                                                \
+        tbl->noexpand=1;                                                         \
+        uthash_noexpand_fyi(tbl);                                                \
+    }                                                                            \
+    uthash_expand_fyi(tbl);                                                      \
+} while(0)
+
+
+/* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
+/* Note that HASH_SORT assumes the hash handle name to be hh. 
+ * HASH_SRT was added to allow the hash handle name to be passed in. */
+#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
+#define HASH_SRT(hh,head,cmpfcn)                                                 \
+do {                                                                             \
+  unsigned _hs_i;                                                                \
+  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
+  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
+  if (head) {                                                                    \
+      _hs_insize = 1;                                                            \
+      _hs_looping = 1;                                                           \
+      _hs_list = &((head)->hh);                                                  \
+      while (_hs_looping) {                                                      \
+          _hs_p = _hs_list;                                                      \
+          _hs_list = NULL;                                                       \
+          _hs_tail = NULL;                                                       \
+          _hs_nmerges = 0;                                                       \
+          while (_hs_p) {                                                        \
+              _hs_nmerges++;                                                     \
+              _hs_q = _hs_p;                                                     \
+              _hs_psize = 0;                                                     \
+              for ( _hs_i = 0; _hs_i  < _hs_insize; _hs_i++ ) {                  \
+                  _hs_psize++;                                                   \
+                  _hs_q = (UT_hash_handle*)((_hs_q->next) ?                      \
+                          ((void*)((char*)(_hs_q->next) +                        \
+                          (head)->hh.tbl->hho)) : NULL);                         \
+                  if (! (_hs_q) ) break;                                         \
+              }                                                                  \
+              _hs_qsize = _hs_insize;                                            \
+              while ((_hs_psize > 0) || ((_hs_qsize > 0) && _hs_q )) {           \
+                  if (_hs_psize == 0) {                                          \
+                      _hs_e = _hs_q;                                             \
+                      _hs_q = (UT_hash_handle*)((_hs_q->next) ?                  \
+                              ((void*)((char*)(_hs_q->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_qsize--;                                               \
+                  } else if ( (_hs_qsize == 0) || !(_hs_q) ) {                   \
+                      _hs_e = _hs_p;                                             \
+                      _hs_p = (UT_hash_handle*)((_hs_p->next) ?                  \
+                              ((void*)((char*)(_hs_p->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_psize--;                                               \
+                  } else if ((                                                   \
+                      cmpfcn(DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_p)), \
+                             DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_q))) \
+                             ) <= 0) {                                           \
+                      _hs_e = _hs_p;                                             \
+                      _hs_p = (UT_hash_handle*)((_hs_p->next) ?                  \
+                              ((void*)((char*)(_hs_p->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_psize--;                                               \
+                  } else {                                                       \
+                      _hs_e = _hs_q;                                             \
+                      _hs_q = (UT_hash_handle*)((_hs_q->next) ?                  \
+                              ((void*)((char*)(_hs_q->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_qsize--;                                               \
+                  }                                                              \
+                  if ( _hs_tail ) {                                              \
+                      _hs_tail->next = ((_hs_e) ?                                \
+                            ELMT_FROM_HH((head)->hh.tbl,_hs_e) : NULL);          \
+                  } else {                                                       \
+                      _hs_list = _hs_e;                                          \
+                  }                                                              \
+                  _hs_e->prev = ((_hs_tail) ?                                    \
+                     ELMT_FROM_HH((head)->hh.tbl,_hs_tail) : NULL);              \
+                  _hs_tail = _hs_e;                                              \
+              }                                                                  \
+              _hs_p = _hs_q;                                                     \
+          }                                                                      \
+          _hs_tail->next = NULL;                                                 \
+          if ( _hs_nmerges <= 1 ) {                                              \
+              _hs_looping=0;                                                     \
+              (head)->hh.tbl->tail = _hs_tail;                                   \
+              DECLTYPE_ASSIGN(head,ELMT_FROM_HH((head)->hh.tbl, _hs_list));      \
+          }                                                                      \
+          _hs_insize *= 2;                                                       \
+      }                                                                          \
+      HASH_FSCK(hh,head);                                                        \
+ }                                                                               \
+} while (0)
+
+/* This function selects items from one hash into another hash. 
+ * The end result is that the selected items have dual presence 
+ * in both hashes. There is no copy of the items made; rather 
+ * they are added into the new hash through a secondary hash 
+ * hash handle that must be present in the structure. */
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
+do {                                                                             \
+  unsigned _src_bkt, _dst_bkt;                                                   \
+  void *_last_elt=NULL, *_elt;                                                   \
+  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
+  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
+  if (src) {                                                                     \
+    for(_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {     \
+      for(_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;                \
+          _src_hh;                                                               \
+          _src_hh = _src_hh->hh_next) {                                          \
+          _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                       \
+          if (cond(_elt)) {                                                      \
+            _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);               \
+            _dst_hh->key = _src_hh->key;                                         \
+            _dst_hh->keylen = _src_hh->keylen;                                   \
+            _dst_hh->hashv = _src_hh->hashv;                                     \
+            _dst_hh->prev = _last_elt;                                           \
+            _dst_hh->next = NULL;                                                \
+            if (_last_elt_hh) { _last_elt_hh->next = _elt; }                     \
+            if (!dst) {                                                          \
+              DECLTYPE_ASSIGN(dst,_elt);                                         \
+              HASH_MAKE_TABLE(hh_dst,dst);                                       \
+            } else {                                                             \
+              _dst_hh->tbl = (dst)->hh_dst.tbl;                                  \
+            }                                                                    \
+            HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);    \
+            HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt],_dst_hh);            \
+            (dst)->hh_dst.tbl->num_items++;                                      \
+            _last_elt = _elt;                                                    \
+            _last_elt_hh = _dst_hh;                                              \
+          }                                                                      \
+      }                                                                          \
+    }                                                                            \
+  }                                                                              \
+  HASH_FSCK(hh_dst,dst);                                                         \
+} while (0)
+
+#define HASH_CLEAR(hh,head)                                                      \
+do {                                                                             \
+  if (head) {                                                                    \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head)=NULL;                                                                 \
+  }                                                                              \
+} while(0)
+
+#ifdef NO_DECLTYPE
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for((el)=(head), (*(char**)(&(tmp)))=(char*)((head)?(head)->hh.next:NULL);       \
+  el; (el)=(tmp),(*(char**)(&(tmp)))=(char*)((tmp)?(tmp)->hh.next:NULL)) 
+#else
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for((el)=(head),(tmp)=DECLTYPE(el)((head)?(head)->hh.next:NULL);                 \
+  el; (el)=(tmp),(tmp)=DECLTYPE(el)((tmp)?(tmp)->hh.next:NULL))
+#endif
+
+/* obtain a count of items in the hash */
+#define HASH_COUNT(head) HASH_CNT(hh,head) 
+#define HASH_CNT(hh,head) ((head)?((head)->hh.tbl->num_items):0)
+
+typedef struct UT_hash_bucket {
+   struct UT_hash_handle *hh_head;
+   unsigned count;
+
+   /* expand_mult is normally set to 0. In this situation, the max chain length
+    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+    * the bucket's chain exceeds this length, bucket expansion is triggered). 
+    * However, setting expand_mult to a non-zero value delays bucket expansion
+    * (that would be triggered by additions to this particular bucket)
+    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+    * (The multiplier is simply expand_mult+1). The whole idea of this
+    * multiplier is to reduce bucket expansions, since they are expensive, in
+    * situations where we know that a particular bucket tends to be overused.
+    * It is better to let its chain length grow to a longer yet-still-bounded
+    * value, than to do an O(n) bucket expansion too often. 
+    */
+   unsigned expand_mult;
+
+} UT_hash_bucket;
+
+/* random signature used only to find hash tables in external analysis */
+#define HASH_SIGNATURE 0xa0111fe1
+#define HASH_BLOOM_SIGNATURE 0xb12220f2
+
+typedef struct UT_hash_table {
+   UT_hash_bucket *buckets;
+   unsigned num_buckets, log2_num_buckets;
+   unsigned num_items;
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+
+   /* in an ideal situation (all buckets used equally), no bucket would have
+    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+   unsigned ideal_chain_maxlen;
+
+   /* nonideal_items is the number of items in the hash whose chain position
+    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+    * hash distribution; reaching them in a chain traversal takes >ideal steps */
+   unsigned nonideal_items;
+
+   /* ineffective expands occur when a bucket doubling was performed, but 
+    * afterward, more than half the items in the hash had nonideal chain
+    * positions. If this happens on two consecutive expansions we inhibit any
+    * further expansion, as it's not helping; this happens when the hash
+    * function isn't a good fit for the key domain. When expansion is inhibited
+    * the hash will still work, albeit no longer in constant time. */
+   unsigned ineff_expands, noexpand;
+
+   uint32_t signature; /* used only to find hash tables in external analysis */
+#ifdef HASH_BLOOM
+   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+   uint8_t *bloom_bv;
+   char bloom_nbits;
+#endif
+
+} UT_hash_table;
+
+typedef struct UT_hash_handle {
+   struct UT_hash_table *tbl;
+   void *prev;                       /* prev element in app order      */
+   void *next;                       /* next element in app order      */
+   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
+   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
+   void *key;                        /* ptr to enclosing struct's key  */
+   unsigned keylen;                  /* enclosing struct's key len     */
+   unsigned hashv;                   /* result of hash-fcn(key)        */
+} UT_hash_handle;
+
+#endif /* UTHASH_H */

--- a/simplehttp/utlist.h
+++ b/simplehttp/utlist.h
@@ -1,0 +1,490 @@
+/*
+Copyright (c) 2007-2010, Troy D. Hanson   http://uthash.sourceforge.net
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTLIST_H
+#define UTLIST_H
+
+#define UTLIST_VERSION 1.9.1
+
+/* 
+ * This file contains macros to manipulate singly and doubly-linked lists.
+ *
+ * 1. LL_ macros:  singly-linked lists.
+ * 2. DL_ macros:  doubly-linked lists.
+ * 3. CDL_ macros: circular doubly-linked lists.
+ *
+ * To use singly-linked lists, your structure must have a "next" pointer.
+ * To use doubly-linked lists, your structure must "prev" and "next" pointers.
+ * Either way, the pointer to the head of the list must be initialized to NULL.
+ * 
+ * ----------------.EXAMPLE -------------------------
+ * struct item {
+ *      int id;
+ *      struct item *prev, *next;
+ * }
+ *
+ * struct item *list = NULL:
+ *
+ * int main() {
+ *      struct item *item;
+ *      ... allocate and populate item ...
+ *      DL_APPEND(list, item);
+ * }
+ * --------------------------------------------------
+ *
+ * For doubly-linked lists, the append and delete macros are O(1)
+ * For singly-linked lists, append and delete are O(n) but prepend is O(1)
+ * The sort macro is O(n log(n)) for all types of single/double/circular lists.
+ */
+
+/* These macros use decltype or the earlier __typeof GNU extension.
+   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   when compiling c++ code), this code uses whatever method is needed
+   or, for VS2008 where neither is available, uses casting workarounds. */
+#ifdef _MSC_VER            /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#define LDECLTYPE(x) decltype(x)
+#else                     /* VS2008 or older (or VS2010 in C mode) */
+#define NO_DECLTYPE
+#define LDECLTYPE(x) char*
+#endif
+#else                      /* GNU, Sun and other compilers */
+#define LDECLTYPE(x) __typeof(x)
+#endif
+
+/* for VS2008 we use some workarounds to get around the lack of decltype,
+ * namely, we always reassign our tmp variable to the list head if we need
+ * to dereference its prev/next pointers, and save/restore the real head.*/
+#ifdef NO_DECLTYPE
+#define _SV(elt,list) _tmp = (char*)(list); {char **_alias = (char**)&(list); *_alias = (elt); }
+#define _NEXT(elt,list) ((char*)((list)->next))
+#define _NEXTASGN(elt,list,to) { char **_alias = (char**)&((list)->next); *_alias=(char*)(to); }
+#define _PREV(elt,list) ((char*)((list)->prev))
+#define _PREVASGN(elt,list,to) { char **_alias = (char**)&((list)->prev); *_alias=(char*)(to); }
+#define _RS(list) { char **_alias = (char**)&(list); *_alias=_tmp; }
+#define _CASTASGN(a,b) { char **_alias = (char**)&(a); *_alias=(char*)(b); }
+#else 
+#define _SV(elt,list)
+#define _NEXT(elt,list) ((elt)->next)
+#define _NEXTASGN(elt,list,to) ((elt)->next)=(to)
+#define _PREV(elt,list) ((elt)->prev)
+#define _PREVASGN(elt,list,to) ((elt)->prev)=(to)
+#define _RS(list)
+#define _CASTASGN(a,b) (a)=(b)
+#endif
+
+/******************************************************************************
+ * The sort macro is an adaptation of Simon Tatham's O(n log(n)) mergesort    *
+ * Unwieldy variable names used here to avoid shadowing passed-in variables.  *
+ *****************************************************************************/
+#define LL_SORT(list, cmp)                                                                     \
+do {                                                                                           \
+  LDECLTYPE(list) _ls_p;                                                                       \
+  LDECLTYPE(list) _ls_q;                                                                       \
+  LDECLTYPE(list) _ls_e;                                                                       \
+  LDECLTYPE(list) _ls_tail;                                                                    \
+  LDECLTYPE(list) _ls_oldhead;                                                                 \
+  LDECLTYPE(list) _tmp;                                                                        \
+  int _ls_insize, _ls_nmerges, _ls_psize, _ls_qsize, _ls_i, _ls_looping;                       \
+  if (list) {                                                                                  \
+    _ls_insize = 1;                                                                            \
+    _ls_looping = 1;                                                                           \
+    while (_ls_looping) {                                                                      \
+      _CASTASGN(_ls_p,list);                                                                   \
+      _CASTASGN(_ls_oldhead,list);                                                             \
+      list = NULL;                                                                             \
+      _ls_tail = NULL;                                                                         \
+      _ls_nmerges = 0;                                                                         \
+      while (_ls_p) {                                                                          \
+        _ls_nmerges++;                                                                         \
+        _ls_q = _ls_p;                                                                         \
+        _ls_psize = 0;                                                                         \
+        for (_ls_i = 0; _ls_i < _ls_insize; _ls_i++) {                                         \
+          _ls_psize++;                                                                         \
+          _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list);                               \
+          if (!_ls_q) break;                                                                   \
+        }                                                                                      \
+        _ls_qsize = _ls_insize;                                                                \
+        while (_ls_psize > 0 || (_ls_qsize > 0 && _ls_q)) {                                    \
+          if (_ls_psize == 0) {                                                                \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list); _ls_qsize--; \
+          } else if (_ls_qsize == 0 || !_ls_q) {                                               \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list); _RS(list); _ls_psize--; \
+          } else if (cmp(_ls_p,_ls_q) <= 0) {                                                  \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list); _RS(list); _ls_psize--; \
+          } else {                                                                             \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list); _ls_qsize--; \
+          }                                                                                    \
+          if (_ls_tail) {                                                                      \
+            _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_ls_e); _RS(list);                     \
+          } else {                                                                             \
+            _CASTASGN(list,_ls_e);                                                             \
+          }                                                                                    \
+          _ls_tail = _ls_e;                                                                    \
+        }                                                                                      \
+        _ls_p = _ls_q;                                                                         \
+      }                                                                                        \
+      _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,NULL); _RS(list);                            \
+      if (_ls_nmerges <= 1) {                                                                  \
+        _ls_looping=0;                                                                         \
+      }                                                                                        \
+      _ls_insize *= 2;                                                                         \
+    }                                                                                          \
+  } else _tmp=NULL; /* quiet gcc unused variable warning */                                    \
+} while (0)
+
+#define DL_SORT(list, cmp)                                                                     \
+do {                                                                                           \
+  LDECLTYPE(list) _ls_p;                                                                       \
+  LDECLTYPE(list) _ls_q;                                                                       \
+  LDECLTYPE(list) _ls_e;                                                                       \
+  LDECLTYPE(list) _ls_tail;                                                                    \
+  LDECLTYPE(list) _ls_oldhead;                                                                 \
+  LDECLTYPE(list) _tmp;                                                                        \
+  int _ls_insize, _ls_nmerges, _ls_psize, _ls_qsize, _ls_i, _ls_looping;                       \
+  if (list) {                                                                                  \
+    _ls_insize = 1;                                                                            \
+    _ls_looping = 1;                                                                           \
+    while (_ls_looping) {                                                                      \
+      _CASTASGN(_ls_p,list);                                                                   \
+      _CASTASGN(_ls_oldhead,list);                                                             \
+      list = NULL;                                                                             \
+      _ls_tail = NULL;                                                                         \
+      _ls_nmerges = 0;                                                                         \
+      while (_ls_p) {                                                                          \
+        _ls_nmerges++;                                                                         \
+        _ls_q = _ls_p;                                                                         \
+        _ls_psize = 0;                                                                         \
+        for (_ls_i = 0; _ls_i < _ls_insize; _ls_i++) {                                         \
+          _ls_psize++;                                                                         \
+          _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list);                               \
+          if (!_ls_q) break;                                                                   \
+        }                                                                                      \
+        _ls_qsize = _ls_insize;                                                                \
+        while (_ls_psize > 0 || (_ls_qsize > 0 && _ls_q)) {                                    \
+          if (_ls_psize == 0) {                                                                \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list); _ls_qsize--; \
+          } else if (_ls_qsize == 0 || !_ls_q) {                                               \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list); _RS(list); _ls_psize--; \
+          } else if (cmp(_ls_p,_ls_q) <= 0) {                                                  \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list); _RS(list); _ls_psize--; \
+          } else {                                                                             \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list); _ls_qsize--; \
+          }                                                                                    \
+          if (_ls_tail) {                                                                      \
+            _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_ls_e); _RS(list);                     \
+          } else {                                                                             \
+            _CASTASGN(list,_ls_e);                                                             \
+          }                                                                                    \
+          _SV(_ls_e,list); _PREVASGN(_ls_e,list,_ls_tail); _RS(list);                          \
+          _ls_tail = _ls_e;                                                                    \
+        }                                                                                      \
+        _ls_p = _ls_q;                                                                         \
+      }                                                                                        \
+      _CASTASGN(list->prev, _ls_tail);                                                         \
+      _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,NULL); _RS(list);                            \
+      if (_ls_nmerges <= 1) {                                                                  \
+        _ls_looping=0;                                                                         \
+      }                                                                                        \
+      _ls_insize *= 2;                                                                         \
+    }                                                                                          \
+  } else _tmp=NULL; /* quiet gcc unused variable warning */                                    \
+} while (0)
+
+#define CDL_SORT(list, cmp)                                                                    \
+do {                                                                                           \
+  LDECLTYPE(list) _ls_p;                                                                       \
+  LDECLTYPE(list) _ls_q;                                                                       \
+  LDECLTYPE(list) _ls_e;                                                                       \
+  LDECLTYPE(list) _ls_tail;                                                                    \
+  LDECLTYPE(list) _ls_oldhead;                                                                 \
+  LDECLTYPE(list) _tmp;                                                                        \
+  LDECLTYPE(list) _tmp2;                                                                       \
+  int _ls_insize, _ls_nmerges, _ls_psize, _ls_qsize, _ls_i, _ls_looping;                       \
+  if (list) {                                                                                  \
+    _ls_insize = 1;                                                                            \
+    _ls_looping = 1;                                                                           \
+    while (_ls_looping) {                                                                      \
+      _CASTASGN(_ls_p,list);                                                                   \
+      _CASTASGN(_ls_oldhead,list);                                                             \
+      list = NULL;                                                                             \
+      _ls_tail = NULL;                                                                         \
+      _ls_nmerges = 0;                                                                         \
+      while (_ls_p) {                                                                          \
+        _ls_nmerges++;                                                                         \
+        _ls_q = _ls_p;                                                                         \
+        _ls_psize = 0;                                                                         \
+        for (_ls_i = 0; _ls_i < _ls_insize; _ls_i++) {                                         \
+          _ls_psize++;                                                                         \
+          _SV(_ls_q,list);                                                                     \
+          if (_NEXT(_ls_q,list) == _ls_oldhead) {                                              \
+            _ls_q = NULL;                                                                      \
+          } else {                                                                             \
+            _ls_q = _NEXT(_ls_q,list);                                                         \
+          }                                                                                    \
+          _RS(list);                                                                           \
+          if (!_ls_q) break;                                                                   \
+        }                                                                                      \
+        _ls_qsize = _ls_insize;                                                                \
+        while (_ls_psize > 0 || (_ls_qsize > 0 && _ls_q)) {                                    \
+          if (_ls_psize == 0) {                                                                \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list); _ls_qsize--; \
+            if (_ls_q == _ls_oldhead) { _ls_q = NULL; }                                        \
+          } else if (_ls_qsize == 0 || !_ls_q) {                                               \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list); _RS(list); _ls_psize--; \
+            if (_ls_p == _ls_oldhead) { _ls_p = NULL; }                                        \
+          } else if (cmp(_ls_p,_ls_q) <= 0) {                                                  \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list); _RS(list); _ls_psize--; \
+            if (_ls_p == _ls_oldhead) { _ls_p = NULL; }                                        \
+          } else {                                                                             \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list); _RS(list); _ls_qsize--; \
+            if (_ls_q == _ls_oldhead) { _ls_q = NULL; }                                        \
+          }                                                                                    \
+          if (_ls_tail) {                                                                      \
+            _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_ls_e); _RS(list);                     \
+          } else {                                                                             \
+            _CASTASGN(list,_ls_e);                                                             \
+          }                                                                                    \
+          _SV(_ls_e,list); _PREVASGN(_ls_e,list,_ls_tail); _RS(list);                          \
+          _ls_tail = _ls_e;                                                                    \
+        }                                                                                      \
+        _ls_p = _ls_q;                                                                         \
+      }                                                                                        \
+      _CASTASGN(list->prev,_ls_tail);                                                          \
+      _CASTASGN(_tmp2,list);                                                                   \
+      _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_tmp2); _RS(list);                           \
+      if (_ls_nmerges <= 1) {                                                                  \
+        _ls_looping=0;                                                                         \
+      }                                                                                        \
+      _ls_insize *= 2;                                                                         \
+    }                                                                                          \
+  } else _tmp=NULL; /* quiet gcc unused variable warning */                                    \
+} while (0)
+
+/******************************************************************************
+ * singly linked list macros (non-circular)                                   *
+ *****************************************************************************/
+#define LL_PREPEND(head,add)                                                                   \
+do {                                                                                           \
+  (add)->next = head;                                                                          \
+  head = add;                                                                                  \
+} while (0)
+
+#define LL_APPEND(head,add)                                                                    \
+do {                                                                                           \
+  LDECLTYPE(head) _tmp;                                                                        \
+  (add)->next=NULL;                                                                            \
+  if (head) {                                                                                  \
+    _tmp = head;                                                                               \
+    while (_tmp->next) { _tmp = _tmp->next; }                                                  \
+    _tmp->next=(add);                                                                          \
+  } else {                                                                                     \
+    (head)=(add);                                                                              \
+  }                                                                                            \
+} while (0)
+
+#define LL_DELETE(head,del)                                                                    \
+do {                                                                                           \
+  LDECLTYPE(head) _tmp;                                                                        \
+  if ((head) == (del)) {                                                                       \
+    (head)=(head)->next;                                                                       \
+  } else {                                                                                     \
+    _tmp = head;                                                                               \
+    while (_tmp->next && (_tmp->next != (del))) {                                              \
+      _tmp = _tmp->next;                                                                       \
+    }                                                                                          \
+    if (_tmp->next) {                                                                          \
+      _tmp->next = ((del)->next);                                                              \
+    }                                                                                          \
+  }                                                                                            \
+} while (0)
+
+/* Here are VS2008 replacements for LL_APPEND and LL_DELETE */
+#define LL_APPEND_VS2008(head,add)                                                             \
+do {                                                                                           \
+  if (head) {                                                                                  \
+    (add)->next = head;     /* use add->next as a temp variable */                             \
+    while ((add)->next->next) { (add)->next = (add)->next->next; }                             \
+    (add)->next->next=(add);                                                                   \
+  } else {                                                                                     \
+    (head)=(add);                                                                              \
+  }                                                                                            \
+  (add)->next=NULL;                                                                            \
+} while (0)
+
+#define LL_DELETE_VS2008(head,del)                                                             \
+do {                                                                                           \
+  if ((head) == (del)) {                                                                       \
+    (head)=(head)->next;                                                                       \
+  } else {                                                                                     \
+    char *_tmp = (char*)(head);                                                                \
+    while (head->next && (head->next != (del))) {                                              \
+      head = head->next;                                                                       \
+    }                                                                                          \
+    if (head->next) {                                                                          \
+      head->next = ((del)->next);                                                              \
+    }                                                                                          \
+    {                                                                                          \
+      char **_head_alias = (char**)&(head);                                                    \
+      *_head_alias = _tmp;                                                                     \
+    }                                                                                          \
+  }                                                                                            \
+} while (0)
+#ifdef NO_DECLTYPE
+#undef LL_APPEND
+#define LL_APPEND LL_APPEND_VS2008
+#undef LL_DELETE
+#define LL_DELETE LL_DELETE_VS2008
+#endif
+/* end VS2008 replacements */
+
+#define LL_FOREACH(head,el)                                                                    \
+    for(el=head;el;el=el->next)
+
+#define LL_FOREACH_SAFE(head,el,tmp)                                                           \
+  for((el)=(head);(el) && (tmp = (el)->next, 1); (el) = tmp)
+
+#define LL_SEARCH_SCALAR(head,out,field,val)                                                   \
+do {                                                                                           \
+    LL_FOREACH(head,out) {                                                                     \
+      if ((out)->field == (val)) break;                                                        \
+    }                                                                                          \
+} while(0) 
+
+#define LL_SEARCH(head,out,elt,cmp)                                                            \
+do {                                                                                           \
+    LL_FOREACH(head,out) {                                                                     \
+      if ((cmp(out,elt))==0) break;                                                            \
+    }                                                                                          \
+} while(0) 
+
+/******************************************************************************
+ * doubly linked list macros (non-circular)                                   *
+ *****************************************************************************/
+#define DL_PREPEND(head,add)                                                                   \
+do {                                                                                           \
+ (add)->next = head;                                                                           \
+ if (head) {                                                                                   \
+   (add)->prev = (head)->prev;                                                                 \
+   (head)->prev = (add);                                                                       \
+ } else {                                                                                      \
+   (add)->prev = (add);                                                                        \
+ }                                                                                             \
+ (head) = (add);                                                                               \
+} while (0)
+
+#define DL_APPEND(head,add)                                                                    \
+do {                                                                                           \
+  if (head) {                                                                                  \
+      (add)->prev = (head)->prev;                                                              \
+      (head)->prev->next = (add);                                                              \
+      (head)->prev = (add);                                                                    \
+      (add)->next = NULL;                                                                      \
+  } else {                                                                                     \
+      (head)=(add);                                                                            \
+      (head)->prev = (head);                                                                   \
+      (head)->next = NULL;                                                                     \
+  }                                                                                            \
+} while (0);
+
+#define DL_DELETE(head,del)                                                                    \
+do {                                                                                           \
+  if ((del)->prev == (del)) {                                                                  \
+      (head)=NULL;                                                                             \
+  } else if ((del)==(head)) {                                                                  \
+      (del)->next->prev = (del)->prev;                                                         \
+      (head) = (del)->next;                                                                    \
+  } else {                                                                                     \
+      (del)->prev->next = (del)->next;                                                         \
+      if ((del)->next) {                                                                       \
+          (del)->next->prev = (del)->prev;                                                     \
+      } else {                                                                                 \
+          (head)->prev = (del)->prev;                                                          \
+      }                                                                                        \
+  }                                                                                            \
+} while (0);
+
+
+#define DL_FOREACH(head,el)                                                                    \
+    for(el=head;el;el=el->next)
+
+/* this version is safe for deleting the elements during iteration */
+#define DL_FOREACH_SAFE(head,el,tmp)                                                           \
+  for((el)=(head);(el) && (tmp = (el)->next, 1); (el) = tmp)
+
+/* these are identical to their singly-linked list counterparts */
+#define DL_SEARCH_SCALAR LL_SEARCH_SCALAR
+#define DL_SEARCH LL_SEARCH
+
+/******************************************************************************
+ * circular doubly linked list macros                                         *
+ *****************************************************************************/
+#define CDL_PREPEND(head,add)                                                                  \
+do {                                                                                           \
+ if (head) {                                                                                   \
+   (add)->prev = (head)->prev;                                                                 \
+   (add)->next = (head);                                                                       \
+   (head)->prev = (add);                                                                       \
+   (add)->prev->next = (add);                                                                  \
+ } else {                                                                                      \
+   (add)->prev = (add);                                                                        \
+   (add)->next = (add);                                                                        \
+ }                                                                                             \
+(head)=(add);                                                                                  \
+} while (0)
+
+#define CDL_DELETE(head,del)                                                                   \
+do {                                                                                           \
+  if ( ((head)==(del)) && ((head)->next == (head))) {                                          \
+      (head) = 0L;                                                                             \
+  } else {                                                                                     \
+     (del)->next->prev = (del)->prev;                                                          \
+     (del)->prev->next = (del)->next;                                                          \
+     if ((del) == (head)) (head)=(del)->next;                                                  \
+  }                                                                                            \
+} while (0);
+
+#define CDL_FOREACH(head,el)                                                                   \
+    for(el=head;el;el=(el->next==head ? 0L : el->next)) 
+
+#define CDL_FOREACH_SAFE(head,el,tmp1,tmp2)                                                    \
+  for((el)=(head), ((tmp1)=(head)?((head)->prev):NULL);                                        \
+      (el) && ((tmp2)=(el)->next, 1);                                                          \
+      ((el) = (((el)==(tmp1)) ? 0L : (tmp2))))
+
+#define CDL_SEARCH_SCALAR(head,out,field,val)                                                  \
+do {                                                                                           \
+    CDL_FOREACH(head,out) {                                                                    \
+      if ((out)->field == (val)) break;                                                        \
+    }                                                                                          \
+} while(0) 
+
+#define CDL_SEARCH(head,out,elt,cmp)                                                           \
+do {                                                                                           \
+    CDL_FOREACH(head,out) {                                                                    \
+      if ((cmp(out,elt))==0) break;                                                            \
+    }                                                                                          \
+} while(0) 
+
+#endif /* UTLIST_H */
+

--- a/simplehttp/utstring.h
+++ b/simplehttp/utstring.h
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2008-2010, Troy D. Hanson   http://uthash.sourceforge.net
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* a dynamic string implementation using macros 
+ * see http://uthash.sourceforge.net/utstring
+ */
+#ifndef UTSTRING_H
+#define UTSTRING_H
+
+#define UTSTRING_VERSION 1.9.1
+
+#ifdef __GNUC__
+#define _UNUSED_ __attribute__ ((__unused__)) 
+#else
+#define _UNUSED_ 
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#define oom() exit(-1)
+
+typedef struct {
+    char *d;
+    size_t n; /* allocd size */
+    size_t i; /* index of first unused byte */
+} UT_string;
+
+#define utstring_reserve(s,amt)                            \
+do {                                                       \
+  if (((s)->n - (s)->i) < (size_t)(amt)) {                 \
+     (s)->d = (char*)realloc((s)->d, (s)->n + amt);        \
+     if ((s)->d == NULL) oom();                            \
+     (s)->n += amt;                                        \
+  }                                                        \
+} while(0)
+
+#define utstring_init(s)                                   \
+do {                                                       \
+  (s)->n = 0; (s)->i = 0; (s)->d = NULL;                   \
+  utstring_reserve(s,100);                                 \
+} while(0)
+
+#define utstring_done(s)                                   \
+do {                                                       \
+  if ((s)->d != NULL) free((s)->d);                        \
+  (s)->n = 0;                                              \
+} while(0)
+
+#define utstring_free(s)                                   \
+do {                                                       \
+  utstring_done(s);                                        \
+  free(s);                                                 \
+} while(0)
+
+#define utstring_new(s)                                    \
+do {                                                       \
+   s = (UT_string*)calloc(sizeof(UT_string),1);            \
+   if (!s) oom();                                          \
+   utstring_init(s);                                       \
+} while(0)
+
+#define utstring_clear(s)                                  \
+do {                                                       \
+  (s)->i = 0;                                              \
+} while(0)
+
+#define utstring_bincpy(s,b,l)                             \
+do {                                                       \
+  utstring_reserve(s,(l)+1);                               \
+  if (l) memcpy(&(s)->d[(s)->i], b, l);                    \
+  s->i += l;                                               \
+  s->d[s->i]='\0';                                         \
+} while(0)
+
+#define utstring_concat(dst,src)                           \
+do {                                                       \
+  utstring_reserve(dst,(src->i)+1);                        \
+  if (src->i) memcpy(&(dst)->d[(dst)->i], src->d, src->i); \
+  dst->i += src->i;                                        \
+  dst->d[dst->i]='\0';                                     \
+} while(0)
+
+#define utstring_len(s) ((unsigned)((s)->i))
+
+#define utstring_body(s) ((s)->d)
+
+_UNUSED_ static void utstring_printf_va(UT_string *s, const char *fmt, va_list ap) {
+   int n;
+   va_list cp;
+   while (1) {
+#ifdef _WIN32
+      cp = ap;
+#else
+      va_copy(cp, ap);
+#endif
+      n = vsnprintf (&s->d[s->i], s->n-s->i, fmt, cp);
+      va_end(cp);
+
+      if ((n > -1) && (n < (int)(s->n-s->i))) {
+        s->i += n;
+        return;
+      }
+
+      /* Else try again with more space. */
+      if (n > -1) utstring_reserve(s,n+1); /* exact */
+      else utstring_reserve(s,(s->n)*2);   /* 2x */
+   }
+}
+_UNUSED_ static void utstring_printf(UT_string *s, const char *fmt, ...) {
+   va_list ap;
+   va_start(ap,fmt);
+   utstring_printf_va(s,fmt,ap);
+   va_end(ap);
+}
+
+#endif /* UTSTRING_H */

--- a/simplequeue/Makefile
+++ b/simplequeue/Makefile
@@ -4,7 +4,7 @@ LIBSIMPLEHTTP ?= ../simplehttp
 LIBSIMPLEHTTP_INC ?= $(LIBSIMPLEHTTP)/..
 LIBSIMPLEHTTP_LIB ?= $(LIBSIMPLEHTTP)
 
-CFLAGS = -I$(LIBSIMPLEHTTP_INC) -I$(LIBEVENT)/include -Wall -g -O2
+CFLAGS = -I$(LIBSIMPLEHTTP_INC) -I$(LIBEVENT)/include -Wall -g
 LIBS = -L$(LIBSIMPLEHTTP_LIB) -L$(LIBEVENT)/lib -levent -lsimplehttp -lm
 
 simplequeue: simplequeue.c

--- a/simplequeue/simplequeue.c
+++ b/simplequeue/simplequeue.c
@@ -6,6 +6,8 @@
 #include "simplehttp/queue.h"
 #include "simplehttp/simplehttp.h"
 
+#define VERSION "1.2";
+
 struct queue_entry {
     TAILQ_ENTRY(queue_entry) entries;
     size_t bytes;
@@ -15,7 +17,6 @@ struct queue_entry {
 TAILQ_HEAD(, queue_entry) queues;
 
 char *progname = "simplequeue";
-char *version = "1.1";
 char *overflow_log = NULL;
 FILE *overflow_log_fp = NULL;
 uint64_t max_depth = 0;
@@ -169,54 +170,53 @@ dump(struct evhttp_request *req, struct evbuffer *evb, void *ctx)
 void usage()
 {   
     fprintf(stderr, "%s: A simple http buffer queue.\n", progname);
-    fprintf(stderr, "Version %s, http://code.google.com/p/simplehttp/\n", version);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "usage:\n");
-    fprintf(stderr, "  %s -- [--overflow_log] [--max_bytes] [--max_depth]\n", progname);
-    fprintf(stderr, "\n");
+    fprintf(stderr, "Version %s, http://code.google.com/p/simplehttp/\n", VERSION);
+    option_help();
     exit(1);
 }   
+
+int version_cb(int value) {
+    fprintf(stdout, "Version: %s\n", VERSION);
+    return 0;
+}
 
 int
 main(int argc, char **argv)
 {
-    int i;
     TAILQ_INIT(&queues);
 
-    for (i=1; i < argc; i++) {
-        if(!strcmp(argv[i], "--overflow_log")) {
-            if(++i >= argc) usage();
-            overflow_log = argv[i];
-        } else if(!strcmp(argv[i], "--max_bytes")) {
-            if(++i >= argc) usage();
-            max_bytes = strtod(argv[i], (char **) NULL);
-        } else if(!strcmp(argv[i], "--max_depth")) {
-            if(++i >= argc) usage();
-            max_depth = strtod(argv[i], (char **) NULL);
-            fprintf(stdout, "max_depth set to %"PRIu64"\n", max_depth);
-        } else if (!strcmp(argv[i], "--help")) {
-            usage();
-        }
-    }
+    define_simplehttp_options();
+    option_define_str("overflow_log", OPT_OPTIONAL, NULL, &overflow_log, NULL, "file to write data beyond --max-depth or --max-bytes");
+    // float?
+    option_define_int("max_bytes", OPT_OPTIONAL, 0, NULL, NULL, "memory limit");
+    option_define_int("max_depth", OPT_OPTIONAL, 0, NULL, NULL, "maximum items in queue");
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
     
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
+    }
+    max_bytes = (size_t)option_get_int("max_bytes");
+    max_depth = (uint64_t)option_get_int("max_depth");
+
     if (overflow_log) {
         overflow_log_fp = fopen(overflow_log, "a");
         if (!overflow_log_fp) {
             perror("fopen failed: ");
             exit(1);
         }
-        fprintf(stdout, "opened overflow_log: %s\n", overflow_log);
+        fprintf(stdout, "opened --overflow-log: %s\n", overflow_log);
     }
 
-    fprintf(stderr, "Version %s, http://code.google.com/p/simplehttp/\n", version);
-    fprintf(stderr, "\"%s -- --help\" for options\n", progname);
+    fprintf(stderr, "Version: %s, http://code.google.com/p/simplehttp/\n", VERSION);
+    fprintf(stderr, "use --help for options\n");
     simplehttp_init();
     signal(SIGHUP, hup_handler);
     simplehttp_set_cb("/put*", put, NULL);
     simplehttp_set_cb("/get*", get, NULL);
     simplehttp_set_cb("/dump*", dump, NULL);
     simplehttp_set_cb("/stats*", stats, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
     
     if (overflow_log_fp) {
         while (depth) {

--- a/simplequeue/simplequeue.c
+++ b/simplequeue/simplequeue.c
@@ -6,7 +6,7 @@
 #include "simplehttp/queue.h"
 #include "simplehttp/simplehttp.h"
 
-#define VERSION "1.2";
+#define VERSION "1.2"
 
 struct queue_entry {
     TAILQ_ENTRY(queue_entry) entries;

--- a/simplequeue/test_simplequeue.py
+++ b/simplequeue/test_simplequeue.py
@@ -13,7 +13,7 @@ RANDOM_STRINGS = [
 #'string with \x00**', # this will fail
 ]
 
-PORT=8082
+PORT=5150
 
 def pytest_generate_tests(metafunc):
     if metafunc.function in [test_put_get]:

--- a/simpletokyo/README.md
+++ b/simpletokyo/README.md
@@ -4,13 +4,23 @@ simpletokyo
 SimpleTokyo provides a light http interface to [Tokyo Tyrant](http://fallabs.com/tokyotyrant/). It supports
 the following commands.
 
-Cmdline usage:
+Command Line Options:
 
-    -A 127.0.0.1 (ttserver host to connect to)
-    -P 1978 (ttserver port to connect to)
-    -a 0.0.0.0 (address to bind to)
-    -p 8080 (port to bind to)
-    -D daemonize (default off)
+  --address=<str>        address to listen on
+                         default: 0.0.0.0
+  --daemon               daemonize process
+  --enable-logging       request logging
+  --group=<str>          run as this group
+  --help                 list usage
+  --port=<int>           port to listen on
+                         default: 8080
+  --root=<str>           chdir and run from this directory
+  --ttserver-host=<str> 
+                         default: 127.0.0.1
+  --ttserver-port=<int> 
+                         default: 1978
+  --user=<str>           run as this user
+  --version              
 
 API endpoints:
 

--- a/simpletokyo/simpletokyo.c
+++ b/simpletokyo/simpletokyo.c
@@ -11,7 +11,7 @@
 #include <json/json.h>
 
 #define NAME                    "simpletokyo"
-#define VERSION                 "1.8"
+#define VERSION                 "1.9"
 #define RECONNECT               5
 
 void finalize_request(struct evhttp_request *req, struct evbuffer *evb, struct evkeyvalq *args, struct json_object *jsobj);
@@ -753,48 +753,26 @@ void exit_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx)
 void info()
 {
     fprintf(stdout, "simpletokyo: a light http interface to Tokyo Tyrant.\n");
-    fprintf(stdout, "Version %s, https://github.com/bitly/simplehttp/tree/master/simpletokyo\n", VERSION);
+    fprintf(stdout, "Version: %s, https://github.com/bitly/simplehttp/tree/master/simpletokyo\n", VERSION);
 }
 
-void usage()
-{
-    fprintf(stderr, "%s: http wrapper for Tokyo Tyrant\n", NAME);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "usage:\n");
-    fprintf(stderr, "\t-A ttserver address\n");
-    fprintf(stderr, "\t-P ttserver port\n");
-    fprintf(stderr, "\t-a listen address\n");
-    fprintf(stderr, "\t-p listen port\n");
-    fprintf(stderr, "\t-D daemonize\n");
-    fprintf(stderr, "\n");
-    exit(1);
+int version_cb(int value) {
+    fprintf(stdout, "Version: %s\n", VERSION);
+    return 0;
 }
 
 int main(int argc, char **argv)
 {
-    int ch;
+    define_simplehttp_options();
+    option_define_str("ttserver_host", OPT_OPTIONAL, "127.0.0.1", &db_host, NULL, NULL);
+    option_define_int("ttserver_port", OPT_OPTIONAL, 1978, &db_port, NULL, NULL);
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
     
-    info();
-    
-    opterr=0;
-    while ((ch = getopt(argc, argv, "A:P:h")) != -1) {
-        if (ch == '?') {
-            optind--; // re-set for next getopt() parse by simplehttp_init
-            break;
-        }
-        switch (ch) {
-        case 'A':
-            db_host = optarg;
-            break;
-        case 'P':
-            db_port = atoi(optarg);
-            break;
-        case 'h':
-            usage();
-            exit(1);
-        }
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
     }
     
+    info();
     memset(&db_status, -1, sizeof(db_status));
     
     simplehttp_init();
@@ -812,7 +790,8 @@ int main(int argc, char **argv)
     simplehttp_set_cb("/incr*", incr_cb, NULL);
     simplehttp_set_cb("/stats*", stats_cb, NULL);
     simplehttp_set_cb("/exit", exit_cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
     
     return 0;
 }

--- a/sortdb/README.md
+++ b/sortdb/README.md
@@ -3,13 +3,20 @@ sortdb
 
 Sorted database server. Makes a tab (or comma) delimitated sorted file accessible via HTTP
 
-Cmdline usage:
-
-    -f /path/to/dbfile
-    -F "\t" (field deliminator)
-    -a 127.0.0.1 (address to listen on)
-    -p 8080 (port to listen on)
-    -D (daemonize)
+	OPTIONS
+	
+	--address=<str>        address to listen on
+	                       default: 0.0.0.0
+	--daemon               daemonize process
+	--db-file=<str>       
+	--enable-logging       request logging
+	--field-separator=<char> field separator (eg: comma, tab, pipe). default: TAB
+	--group=<str>          run as this group
+	--help                 list usage
+	--port=<int>           port to listen on
+	                       default: 8080
+	--root=<str>           chdir and run from this directory
+	--user=<str>           run as this user
 
 API endpoints:
 

--- a/sortdb/sortdb.c
+++ b/sortdb/sortdb.c
@@ -13,7 +13,7 @@
 #include <simplehttp/simplehttp.h>
 
 #define NAME        "sortdb"
-#define VERSION     "1.4.1"
+#define VERSION     "1.5"
 #define DEBUG       1
 
 void stats_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx);
@@ -22,7 +22,6 @@ void reload_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx);
 void exit_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx);
 char *prev_line(char *pos);
 char *map_search(char *key, size_t keylen, char *lower, char *upper, int *seeks, int allow_prefix);
-void usage();
 void info();
 int main(int argc, char **argv);
 void close_dbfile();
@@ -295,21 +294,7 @@ void exit_cb(struct evhttp_request *req, struct evbuffer *evb, void *ctx)
 void info()
 {
     fprintf(stdout, "%s: sorted database server.\n", NAME);
-    fprintf(stdout, "Version %s, https://github.com/bitly/simplehttp/tree/master/sortdb\n", VERSION);
-}
-
-void usage()
-{
-    fprintf(stderr, "Provides search access to sorted tab delimited files\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "usage: sortdb\n");
-    fprintf(stderr, "\t-f /path/to/dbfile\n");
-    fprintf(stderr, "\t-F \"\\t\" (field deliminator)\n");
-    fprintf(stderr, "\t-a 127.0.0.1 (address to listen on)\n");
-    fprintf(stderr, "\t-p 8080 (port to listen on)\n");
-    fprintf(stderr, "\t-D (daemonize)\n");
-    fprintf(stderr, "\n");
-    exit(1);
+    fprintf(stdout, "Version: %s, https://github.com/bitly/simplehttp/tree/master/sortdb\n", VERSION);
 }
 
 void hup_handler(int signum)
@@ -357,40 +342,28 @@ void open_dbfile()
     }
 }
 
+int version_cb(int value) {
+    fprintf(stdout, "Version: %s\n", VERSION);
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
-    int ch;
+    define_simplehttp_options();
+    option_define_str("db_file", OPT_REQUIRED, NULL, &db_filename, NULL, NULL);
+    option_define_char("field_separator", OPT_OPTIONAL, '\0', &deliminator, NULL, "field separator (eg: comma, tab, pipe). default: TAB");
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
     
-    info();
-    
-    opterr=0;
-    while ((ch = getopt(argc, argv, "f:F:h")) != -1) {
-        if (ch == '?') {
-            optind--; // re-set for next getopt() parse by simplehttp_init
-            break;
-        }
-        switch (ch) {
-        case 'f':
-            db_filename = optarg;
-            open_dbfile();
-            break;
-        case 'F':
-            // field deliminator
-            if (strlen(optarg) != 1) {
-                fprintf(stderr, "Field (-F) deliminator must be a single character");
-                usage();
-                exit(1);
-            }
-            deliminator = optarg[0];
-            break;
-        case 'h':
-            usage();
-            exit(1);
-        }
+    if (!option_parse_command_line(argc, argv)){
+        return 1;
     }
+
+    info();
+    fprintf(stdout, "--field-separator is \"%c\"\n", deliminator);
+    fprintf(stdout, "--db-file is %s\n", db_filename);
     
+    open_dbfile();
     if (map_base == NULL) {
-        usage();
         exit(1);
     }
     
@@ -402,7 +375,8 @@ int main(int argc, char **argv)
     simplehttp_set_cb("/stats*", stats_cb, NULL);
     simplehttp_set_cb("/reload", reload_cb, NULL);
     simplehttp_set_cb("/exit", exit_cb, NULL);
-    simplehttp_main(argc, argv);
+    simplehttp_main();
+    free_options();
     
     return 0;
 }

--- a/sortdb/test.sh
+++ b/sortdb/test.sh
@@ -26,7 +26,7 @@ run_vg (){
 err=$?
 
 ln -s -f test.tab test.db
-run_vg sortdb "-f test.db -a 127.0.0.1 -p 8080"
+run_vg sortdb "--db-file=test.db --address=127.0.0.1 --port=8080"
 sleep 1
 for key in a b c m o zzzzzzzzzzzzzzzzzzzzzzzz zzzzzzzzzzzzzzzzzzzzzzzzz zzzzzzzzzzzzzzzzzzzzzzzzzz; do 
     echo "/get?key=$key" >> $testsubdir/test.out


### PR DESCRIPTION
simplehttp has historically used single variable options because it's easy (enough) to write code using `getopt` to parse options. This unfortunately leads to ambiguous options. is -d for daemonize or debug? is -v for verbose or version? Additionally with getopt it is necessary to write custom code to generate a usage output for every program.

I propose a simplehttp options library that allows for type casted options to be defined and parsed. options.c and options.h are independent of the simplehttp libevent code and can be re-used in other projects.

For simplicity sake, options should always follow the format --key=value (or for boolean values --key or --key=true|false). keys can be either --key-name or --key_name format.

When options are defined, it is also possible to pass along a default value, to make an option required, and to document the option with a help string that will be used in generating command line usage with --help
