### PR TITLE
Add mget call to simplequeue

### DIFF
--- a/simplequeue/SimpleQueue.py
+++ b/simplequeue/SimpleQueue.py
@@ -44,7 +44,18 @@ class SimpleQueue:
         except:
             traceback.print_tb(sys.exc_info()[2])
             return False
-            
+
+    def mget(self, timeout_ms=500, num_items=1, separator=None):
+        url = "http://%s:%d/mget?items=%d" % (self.address, self.port, num_items)
+        if separator:
+            url += "&separator=" + separator
+        
+        try:
+            return self.request(url, timeout_ms)
+        except:
+            traceback.print_tb(sys.exc_info()[2])
+            return False
+                        
     def dump(self, timeout_ms=500):
         url = "http://%s:%d/dump" % (self.address, self.port)
         

--- a/simplequeue/test_simplequeue.py
+++ b/simplequeue/test_simplequeue.py
@@ -26,6 +26,32 @@ def test_put_get(data):
     d = c.get()
     assert d == data
 
+def test_put_mget():
+    c = SimpleQueue(port=PORT, debug=True)
+    c.put('test1')
+    c.put('test2')
+    items = c.mget(num_items=10).splitlines()
+    assert len(items) == 2
+    assert items[0] == 'test1'
+    assert items[1] == 'test2'
+    c.put('test3')
+    c.put('test4')
+    items = c.mget().splitlines()
+    assert len(items) == 1
+    assert items[0] == 'test3'
+    assert c.get() == 'test4'
+    
+def test_mget_badindex():
+    c = SimpleQueue(port=PORT, debug=True)
+    msg = c.mget(num_items=-2)
+    assert msg == 'number of items must be > 0\n'
+    msg2 = c.mget(num_items=0)
+    assert msg2 == 'number of items must be > 0\n'
+    c.put('test1')
+    items = c.mget().splitlines()
+    assert len(items) == 1
+    assert items[0] == 'test1'
+    
 def test_order():
     # first thing put in, should be first thing out
     c = SimpleQueue(port=PORT, debug=True)


### PR DESCRIPTION
Added mget call.  Gets multiple items per single call, newline separated.

I also added the unit tests and updated the SimpleQueue class.  I tested this on the omni.  It seems to increase performance versus get calls but I don't have a specific number on how much that is.

Let me know if this code looks good.  My C is rusty.
