### PR TITLE
support non-chunked pubsub endpoints

### DIFF
--- a/ps_to_file/ps_to_file.c
+++ b/ps_to_file/ps_to_file.c
@@ -13,7 +13,7 @@
 #define _DEBUG(...) do {;} while (0)
 #endif
 
-#define VERSION "1.2"
+#define VERSION "1.3"
 
 struct output_metadata {
     char *filename_format;
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
     data->output_file = NULL;
     
     if (simplehttp_parse_url(pubsub_url, strlen(pubsub_url), &address, &port, &path)) {
-        pubsub_to_pubsub_main(address, port, path, process_message_cb, data);
+        pubsubclient_main(address, port, path, process_message_cb, data);
         
         if (data->output_file) {
             fclose(data->output_file);

--- a/ps_to_http/ps_to_http.c
+++ b/ps_to_http/ps_to_http.c
@@ -13,7 +13,7 @@
 #define _DEBUG(...) do {;} while (0)
 #endif
 
-#define VERSION "0.3.1"
+#define VERSION "0.4"
 
 struct destination_url {
     char *address;
@@ -60,7 +60,7 @@ void free_destination_url(struct destination_url *sq_dest)
 
 void finish_destination_cb(struct evhttp_request *req, void *cb_arg)
 {
-    _DEBUG("finish_destination_cb()\n");
+    //_DEBUG("finish_destination_cb()\n");
 }
 
 void process_message_cb(char *message, void *cb_arg)
@@ -84,12 +84,12 @@ void process_message_cb(char *message, void *cb_arg)
             evb = evbuffer_new();
             encoded_message = simplehttp_encode_uri(message);
             evbuffer_add_printf(evb, destination->path, encoded_message);
-            _DEBUG("process_message_cb(GET %s)\n", (char *)EVBUFFER_DATA(evb));
+            //_DEBUG("process_message_cb(GET %s)\n", (char *)EVBUFFER_DATA(evb));
             new_async_request(destination->address, destination->port, (char *)EVBUFFER_DATA(evb), finish_destination_cb, NULL);
             evbuffer_free(evb);
             free(encoded_message);
         } else {
-            _DEBUG("process_message_cb(POST %s:%d%s)\n", destination->address, destination->port, destination->path);
+            //_DEBUG("process_message_cb(POST %s:%d%s)\n", destination->address, destination->port, destination->path);
             new_async_request_with_body(destination->address, destination->port, destination->path, message, finish_destination_cb, NULL);
         }
         
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
     init_async_connection_pool(1);
     
     if (simplehttp_parse_url(pubsub_url, strlen(pubsub_url), &address, &port, &path)) {
-        pubsub_to_pubsub_main(address, port, path, process_message_cb, NULL);
+        pubsubclient_main(address, port, path, process_message_cb, NULL);
         
         free(address);
         free(path);

--- a/pubsubclient/Makefile
+++ b/pubsubclient/Makefile
@@ -9,9 +9,9 @@ AR = ar
 AR_FLAGS = rc
 RANLIB = ranlib
 
-libpubsubclient.a: pubsubclient.o
+libpubsubclient.a: pubsubclient.o stream_request.o
 	/bin/rm -f $@
-	$(AR) $(AR_FLAGS) $@ $<
+	$(AR) $(AR_FLAGS) $@ $^
 	$(RANLIB) $@
 
 all: libpubsubclient.a

--- a/pubsubclient/pubsubclient.c
+++ b/pubsubclient/pubsubclient.c
@@ -1,4 +1,3 @@
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -6,6 +5,7 @@
 #include <simplehttp/simplehttp.h>
 #include <signal.h>
 #include "pubsubclient.h"
+#include "stream_request.h"
 
 #ifdef DEBUG
 #define _DEBUG(...) fprintf(stdout, __VA_ARGS__)
@@ -13,9 +13,18 @@
 #define _DEBUG(...) do {;} while (0)
 #endif
 
-struct global_data {
+static int chunked = 0;
+static struct GlobalData *data = NULL;
+static struct StreamRequest *stream_request = NULL;
+static struct evhttp_connection *evhttp_source_connection = NULL;
+static struct evhttp_request *evhttp_source_request = NULL;
+
+struct GlobalData {
     void (*cb)(char *data, void *cbarg);
     void *cbarg;
+    const char *source_address;
+    int source_port;
+    const char *path;
 };
 
 void pubsubclient_termination_handler(int signum)
@@ -23,52 +32,107 @@ void pubsubclient_termination_handler(int signum)
     event_loopbreak();
 }
 
-int parse_one_message(struct evhttp_request *req, void *arg)
+int pubsubclient_parse_one_message(struct evbuffer *evb, void *arg)
 {
     char *line;
     size_t line_len;
-    struct global_data *client_data;
+    struct GlobalData *client_data;
     char *data;
+    int has_more = 0;
     
-    _DEBUG("parse_one_message()\n");
+    _DEBUG("pubsubclient_parse_one_message()\n");
     
-    client_data = (struct global_data *)arg;
-    line = evbuffer_readline(req->input_buffer);
-    line_len = line ? strlen(line) : 0;
-    if (line && line_len) {
-        evbuffer_drain(req->input_buffer, line_len);
+    client_data = (struct GlobalData *)arg;
+    line = evbuffer_readline(evb);
+    if (line && (line_len = strlen(line))) {
         _DEBUG("line (%p): %s (%d)\n", line, line, line_len);
         (*client_data->cb)(line, client_data->cbarg);
-        if (EVBUFFER_LENGTH(req->input_buffer)) {
-            free(line);
-            return 1;
+        if (EVBUFFER_LENGTH(evb)) {
+            has_more = 1;
         }
     }
     free(line);
-    return 0;
+    return has_more;
 }
 
-void source_callback(struct evhttp_request *req, void *arg)
+void pubsubclient_source_readcb(struct bufferevent *bev, void *arg)
 {
-    // keep parsing out messages until there aren't any left
-    while (parse_one_message(req, arg)) {}
+    while (pubsubclient_parse_one_message(EVBUFFER_INPUT(bev), arg)) {}
 }
 
-void http_source_request_done(struct evhttp_request *req, void *arg)
+void pubsubclient_errorcb(struct bufferevent *bev, void *arg)
 {
-    _DEBUG("http_chunked_request_done\n");
-    if (!req || req->response_code != HTTP_OK) {
-        fprintf(stderr, "FAILED on sub connection\n");
+    fprintf(stderr, "ERROR: request failed\n");
+    event_loopbreak();
+}
+
+void pubsubclient_source_request_done(struct evhttp_request *req, void *arg)
+{
+    _DEBUG("pubsubclient_source_request_done()\n");
+    
+    if (!req || (req->response_code != HTTP_OK)) {
+        fprintf(stderr, "ERROR: request failed\n");
         event_loopbreak();
     }
-    _DEBUG("DONE on sub connection\n");
 }
 
-int pubsub_to_pubsub_main(const char *source_address, int source_port, const char *path, void (*cb)(char *data, void *arg), void *cbarg)
+void pubsubclient_source_callback(struct evhttp_request *req, void *arg)
 {
-    struct evhttp_connection *evhttp_source_connection = NULL;
-    struct evhttp_request *evhttp_source_request = NULL;
-    struct global_data *data;
+    // keep parsing out messages until there aren't any left
+    while (pubsubclient_parse_one_message(req->input_buffer, arg)) {}
+}
+
+void pubsubclient_autodetect_headercb(struct bufferevent *bev, struct evkeyvalq *headers, void *arg)
+{
+    const char *encoding_header = NULL;
+    struct GlobalData *client_data = NULL;
+    
+    _DEBUG("pubsubclient_autodetect_headercb() headers: %p\n", headers);
+    
+    if ((encoding_header = evhttp_find_header(headers, "Transfer-Encoding")) != NULL) {
+        if (strncmp(encoding_header, "chunked", 7) == 0) {
+            chunked = 1;
+        }
+    }
+    
+    // turn off the events for this buffer
+    // its free'd later
+    bufferevent_disable(bev, EV_READ);
+    
+    _DEBUG("chunked = %d\n", chunked);
+    
+    client_data = (struct GlobalData *)arg;
+    if (chunked) {
+        // use libevent's built in evhttp methods to parse chunked responses
+        evhttp_source_connection = evhttp_connection_new(client_data->source_address, client_data->source_port);
+        if (evhttp_source_connection == NULL) {
+            fprintf(stdout, "FAILED CONNECT TO SOURCE %s:%d\n", client_data->source_address, client_data->source_port);
+            exit(1);
+        }
+        
+        evhttp_source_request = evhttp_request_new(pubsubclient_source_request_done, data);
+        evhttp_add_header(evhttp_source_request->output_headers, "Host", client_data->source_address);
+        evhttp_request_set_chunked_cb(evhttp_source_request, pubsubclient_source_callback);
+        
+        if (evhttp_make_request(evhttp_source_connection, evhttp_source_request, EVHTTP_REQ_GET, client_data->path) == -1) {
+            fprintf(stdout, "FAILED make_request to source\n");
+            evhttp_connection_free(evhttp_source_connection);
+            exit(1);
+        }
+    } else {
+        // use our stream_request library to handle non-chunked
+        stream_request = new_stream_request("GET", client_data->source_address, client_data->source_port, client_data->path, 
+                                NULL, pubsubclient_source_readcb, pubsubclient_errorcb, arg);
+        if (!stream_request) {
+            fprintf(stdout, "FAILED CONNECT TO SOURCE %s:%d\n", client_data->source_address, client_data->source_port);
+            exit(1);
+        }
+    }
+}
+
+int pubsubclient_main(const char *source_address, int source_port, const char *path, void (*cb)(char *data, void *arg), void *cbarg)
+{
+    struct StreamRequest *autodetect_sr = NULL;
     
     signal(SIGINT, pubsubclient_termination_handler);
     signal(SIGQUIT, pubsubclient_termination_handler);
@@ -76,29 +140,33 @@ int pubsub_to_pubsub_main(const char *source_address, int source_port, const cha
     
     event_init();
     
+    data = calloc(1, sizeof(struct GlobalData));
+    data->cb = cb;
+    data->cbarg = cbarg;
+    data->source_address = source_address;
+    data->source_port = source_port;
+    data->path = path;
+    
+    // perform a request for headers so we can autodetect whether or not we're
+    // getting a chunked response
     fprintf(stdout, "CONNECTING TO http://%s:%d%s\n", source_address, source_port, path);
-    evhttp_source_connection = evhttp_connection_new(source_address, source_port);
-    if (evhttp_source_connection == NULL) {
+    autodetect_sr = new_stream_request("HEAD", source_address, source_port, path, 
+                        pubsubclient_autodetect_headercb, NULL, pubsubclient_errorcb, data);
+    if (!autodetect_sr) {
         fprintf(stdout, "FAILED CONNECT TO SOURCE %s:%d\n", source_address, source_port);
         exit(1);
     }
     
-    data = calloc(1, sizeof(struct global_data));
-    data->cb = cb;
-    data->cbarg = cbarg;
+    event_dispatch();
     
-    evhttp_source_request = evhttp_request_new(http_source_request_done, data);
-    evhttp_add_header(evhttp_source_request->output_headers, "Host", source_address);
-    evhttp_request_set_chunked_cb(evhttp_source_request, source_callback);
+    free_stream_request(autodetect_sr);
     
-    if (evhttp_make_request(evhttp_source_connection, evhttp_source_request, EVHTTP_REQ_GET, path) == -1) {
-        fprintf(stdout, "FAILED make_request to source\n");
+    if (chunked) {
         evhttp_connection_free(evhttp_source_connection);
-        return 1;
+    } else {
+        free_stream_request(stream_request);
     }
     
-    event_dispatch();
-    evhttp_connection_free(evhttp_source_connection);
     free(data);
     
     return 0;

--- a/pubsubclient/pubsubclient.h
+++ b/pubsubclient/pubsubclient.h
@@ -1,1 +1,15 @@
-int pubsub_to_pubsub_main(const char *source_address, int source_port, const char *path, void (*cb)(char *data, void *arg), void *cbarg);
+#ifndef __pubsubclient_h
+#define __pubsubclient_h
+
+struct StreamRequest;
+
+int pubsubclient_main(const char *source_address, int source_port, const char *path, void (*cb)(char *data, void *arg), void *cbarg);
+
+struct StreamRequest *new_stream_request(const char *method, const char *source_address, int source_port, const char *path, 
+    void (*header_cb)(struct bufferevent *bev, struct evkeyvalq *headers, void *arg), 
+    void (*read_cb)(struct bufferevent *bev, void *arg), 
+    void (*error_cb)(struct bufferevent *bev, void *arg), 
+    void *arg);
+void free_stream_request(struct StreamRequest *sr);
+
+#endif

--- a/pubsubclient/stream_request.c
+++ b/pubsubclient/stream_request.c
@@ -1,0 +1,163 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <errno.h>
+#include <simplehttp/queue.h>
+#include <simplehttp/simplehttp.h>
+#include "stream_request.h"
+
+#ifdef DEBUG
+#define _DEBUG(...) fprintf(stdout, __VA_ARGS__)
+#else
+#define _DEBUG(...) do {;} while (0)
+#endif
+
+enum read_states { read_firstline, read_headers, read_body };
+
+struct StreamRequest *new_stream_request(const char *method, const char *source_address, int source_port, const char *path, 
+    void (*header_cb)(struct bufferevent *bev, struct evkeyvalq *headers, void *arg), 
+    void (*read_cb)(struct bufferevent *bev, void *arg), 
+    void (*error_cb)(struct bufferevent *bev, void *arg), 
+    void *arg)
+{
+    struct StreamRequest *sr;
+    int fd;
+    struct evbuffer *http_request;
+    
+    fd = stream_request_connect(source_address, source_port);
+    if (fd == -1) {
+        return NULL;
+    }
+    
+    sr = malloc(sizeof(struct StreamRequest));
+    sr->fd = fd;
+    sr->state = read_firstline;
+    sr->header_cb = header_cb;
+    sr->read_cb = read_cb;
+    sr->error_cb = error_cb;
+    sr->arg = arg;
+    sr->bev = bufferevent_new(sr->fd, stream_request_readcb, stream_request_writecb, stream_request_errorcb, sr);
+    http_request = evbuffer_new();
+    evbuffer_add_printf(http_request, "%s %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", method, path, source_address);
+    bufferevent_write(sr->bev, (char *)EVBUFFER_DATA(http_request), EVBUFFER_LENGTH(http_request));
+    evbuffer_free(http_request);
+    
+    return sr;
+}
+
+void free_stream_request(struct StreamRequest *sr)
+{
+    if (sr) {
+        stream_request_disconnect(sr->fd);
+        bufferevent_free(sr->bev);
+        free(sr);
+    }
+}
+
+int stream_request_connect(const char *address, int port)
+{
+    struct addrinfo ai, *aitop;
+    char strport[NI_MAXSERV];
+    struct sockaddr *sa;
+    int slen;
+    int fd;
+    
+    memset(&ai, 0, sizeof(struct addrinfo));
+    ai.ai_family = AF_INET;
+    ai.ai_socktype = SOCK_STREAM;
+    snprintf(strport, sizeof(strport), "%d", port);
+    if (getaddrinfo(address, strport, &ai, &aitop) != 0) {
+        fprintf(stderr, "ERROR: getaddrinfo() failed\n");
+        return -1;
+    }
+    sa = aitop->ai_addr;
+    slen = aitop->ai_addrlen;
+    
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd == -1) {
+        fprintf(stderr, "ERROR: socket() failed\n");
+        return -1;
+    }
+    
+    if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1) {
+        fprintf(stderr, "ERROR: fcntl(O_NONBLOCK) failed\n");
+        return -1;
+    }
+    
+    if (connect(fd, sa, slen) == -1) {
+        if (errno != EINPROGRESS) {
+            fprintf(stderr, "ERROR: connect() failed\n");
+            return -1;
+        }
+    }
+    
+    freeaddrinfo(aitop);
+    
+    return fd;
+}
+
+int stream_request_disconnect(int fd)
+{
+    EVUTIL_CLOSESOCKET(fd);
+}
+
+void stream_request_readcb(struct bufferevent *bev, void *arg)
+{
+    struct evhttp_request *req;
+    struct StreamRequest *sr = (struct StreamRequest *)arg;
+    
+    _DEBUG("stream_request_readcb()\n");
+    
+    switch (sr->state) {
+        case read_firstline:
+            req = evhttp_request_new(NULL, NULL);
+            req->kind = EVHTTP_RESPONSE;
+            // 1 is the constant ALL_DATA_READ in http-internal.h
+            if (evhttp_parse_firstline(req, EVBUFFER_INPUT(bev)) == 1) {
+                sr->state = read_headers;
+            }
+            evhttp_request_free(req);
+            // dont break, try to parse the headers too
+        case read_headers:
+            req = evhttp_request_new(NULL, NULL);
+            req->kind = EVHTTP_RESPONSE;
+            // 1 is the constant ALL_DATA_READ in http-internal.h
+            if (evhttp_parse_headers(req, EVBUFFER_INPUT(bev)) == 1) {
+                if (sr->header_cb) {
+                    sr->header_cb(sr->bev, req->input_headers, sr->arg);
+                }
+                sr->state = read_body;
+            }
+            evhttp_request_free(req);
+            break;
+        case read_body:
+            if (sr->read_cb) {
+                sr->read_cb(sr->bev, sr->arg);
+            }
+            break;
+    }
+}
+
+void stream_request_writecb(struct bufferevent *bev, void *arg)
+{
+    _DEBUG("stream_request_writecb()\n");
+    
+    if (EVBUFFER_LENGTH(EVBUFFER_OUTPUT(bev)) == 0) {
+        bufferevent_enable(bev, EV_READ);
+    }
+}
+
+void stream_request_errorcb(struct bufferevent *bev, short what, void *arg)
+{
+    struct StreamRequest *sr = (struct StreamRequest *)arg;
+    
+    _DEBUG("stream_request_errorcb()\n");
+    
+    if (sr->error_cb) {
+        sr->error_cb(sr->bev, sr->arg);
+    }
+}

--- a/pubsubclient/stream_request.h
+++ b/pubsubclient/stream_request.h
@@ -1,0 +1,20 @@
+#ifndef __stream_request_h
+#define __stream_request_h
+
+struct StreamRequest {
+    int fd;
+    struct bufferevent *bev;
+    void *arg;
+    int state;
+    void (*header_cb)(struct bufferevent *bev, struct evkeyvalq *headers, void *arg);
+    void (*read_cb)(struct bufferevent *bev, void *arg);
+    void (*error_cb)(struct bufferevent *bev, void *arg);
+};
+
+int stream_request_connect(const char *address, int port);
+int stream_request_disconnect(int fd);
+void stream_request_readcb(struct bufferevent *bev, void *arg);
+void stream_request_writecb(struct bufferevent *bev, void *arg);
+void stream_request_errorcb(struct bufferevent *bev, short what, void *arg);
+
+#endif

--- a/simplehttp/async_simplehttp.c
+++ b/simplehttp/async_simplehttp.c
@@ -133,7 +133,7 @@ struct AsyncCallback *new_async_request_with_body(char *address, int port, char 
     
     if (body) {
         evbuffer_add(callback->request->output_buffer, body, strlen(body));
-        request_method=EVHTTP_REQ_POST;
+        request_method = EVHTTP_REQ_POST;
     }
     
     AS_DEBUG("calling evhttp_make_request to %s (%p)\n", path, callback->request);

--- a/simplehttp/log.c
+++ b/simplehttp/log.c
@@ -54,7 +54,7 @@ void simplehttp_log(const char *host, struct evhttp_request *req, uint64_t req_t
         response_code = req->response_code;
         method = simplehttp_method(req);
         uri = req->uri;
-        type = req->type;
+        type = (req->kind == EVHTTP_REQUEST) ? req->type : -1;
     } else {
         code = 'E';
         response_code = 0;


### PR DESCRIPTION
updates to `pubsubclient` in order to support both chunked and non-chunked source pubsub endpoints via autodetection.

introduce `stream_request.c` (this _could_ move into `libsimplehttp`) to perform non-blocking HTTP stream requests
