### PR TITLE
update simpleleveldb to accept POST's

### DIFF
--- a/simpleleveldb/README.md
+++ b/simpleleveldb/README.md
@@ -61,6 +61,8 @@ API endpoints:
  * /put
 
     parameters: `key`, `value`, `format`
+    
+    Note: `value` can also be specified as the raw POST body content
 
  * /del
 


### PR DESCRIPTION
as the title says. This updates simpleleveldb's /put endpoint to accept POST's. 

The key must still be specified in the URL query parameters, but the raw post body can be used to supply the value
