### PR TITLE
library to track arbitary profiler stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ simple and straightforward to write.
 The following libraries and daemons are included:
  
  * `host_pool` - a library for dealing with endpoint selection, pooling, failure, recovery, and backoff
+ * `profiler_stats` - a library to track arbitrary profiler timings for average, 95%, 99%, 100% time
  * `ps_to_http` - a daemon built on top of pubsubclient to write messages from a source pubsub to destination simplequeue or pubsub server
  * `ps_to_file` - a daemon built on top of pubsubclient to write messages from a source pubsub to time rolled output files
  * `pubsub` - a daemon that receives data via HTTP POST events and writes to all subscribed long-lived HTTP connections

--- a/profiler_stats/Makefile
+++ b/profiler_stats/Makefile
@@ -1,0 +1,23 @@
+TARGET ?= /usr/local
+
+CFLAGS = -I. -I.. -g -Wall -O2
+AR = ar
+AR_FLAGS = rc
+RANLIB = ranlib
+
+libprofiler_stats.a: profiler_stats.o profiler_stats.h
+	/bin/rm -f $@
+	$(AR) $(AR_FLAGS) $@ $^
+	$(RANLIB) $@
+
+all: libprofiler_stats.a
+
+install:
+	/usr/bin/install -d $(TARGET)/lib/
+	/usr/bin/install -d $(TARGET)/bin/
+	/usr/bin/install -d $(TARGET)/include/profiler_stats
+	/usr/bin/install libprofiler_stats.a $(TARGET)/lib/
+	/usr/bin/install profiler_stats.h $(TARGET)/include/profiler_stats
+
+clean:
+	/bin/rm -f *.a *.o

--- a/profiler_stats/README.md
+++ b/profiler_stats/README.md
@@ -1,0 +1,57 @@
+profiler_stats
+=============
+
+a library to track arbitrary profiler timings for average, 95%, 99%, 100% time
+
+the library enforces a rolling window for data collection.  currently it will consider either 5000 entries or the 
+last 5 minutes of entries, whichever is smaller.
+
+compiling
+---------
+
+there are no additional dependencies other than client applications needing to link against `libm` aka `-lm`
+
+```
+cd simplehttp/profiler_stats
+make
+make install
+```
+
+usage
+-----
+
+no initialization is required, the general process is as follows (NOTE: client is responsible 
+for `free()` of all returned structures as well as a final call to `profiler_stats_free()`):
+
+```
+#include <profiler_stats/profiler_stats.h>
+#include <utlist.h>
+
+void my_function()
+{
+    profiler_ts start_ts;
+    
+    profiler_get_ts(&start_ts);
+    
+    // do some work
+    
+    profiler_stats_store("stat_name", start_ts);
+}
+
+void my_stats_output()
+{
+    struct ProfilerStat *pstat;
+    struct ProfilerReturn *ret;
+    
+    // LL_FOREACH() is from utlist.h http://uthash.sourceforge.net/
+    LL_FOREACH(profiler_stats_get_all(), pstat) {
+        ret = profiler_get_stats(pstat);
+        fprintf(stdout, "100%%: %"PRIu64"\n", ret->hundred_percent);
+        fprintf(stdout, "99%%: %"PRIu64"\n", ret->ninety_nine_percent);
+        fprintf(stdout, "95%%: %"PRIu64"\n", ret->ninety_five_percent);
+        fprintf(stdout, "avg: %"PRIu64"\n", ret->average);
+        fprintf(stdout, "count: %"PRIu64"\n", ret->count);
+        free(ret);
+    }
+}
+```

--- a/profiler_stats/profiler_stats.c
+++ b/profiler_stats/profiler_stats.c
@@ -1,0 +1,208 @@
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <time.h>
+#include <sys/time.h>
+#include <math.h>
+#include <simplehttp/uthash.h>
+#include <simplehttp/utlist.h>
+#include "profiler_stats.h"
+
+#define STAT_WINDOW_USEC 300000000
+#define STAT_WINDOW_COUNT 5000
+
+static struct ProfilerStat *profiler_stats = NULL;
+
+void profiler_stats_reset()
+{
+    struct ProfilerStat *pstat, *tmp_pstat;
+    struct ProfilerData *data, *tmp_data;
+    
+    HASH_ITER(hh, profiler_stats, pstat, tmp_pstat) {
+        pstat->count = 0;
+        pstat->index = 0;
+        DL_FOREACH_SAFE(pstat->data, data, tmp_data) {
+            DL_DELETE(pstat->data, data);
+            free(data);
+        }
+    }
+}
+
+void profiler_stats_store(const char *name, profiler_ts start_ts)
+{
+    struct ProfilerData *data;
+    struct ProfilerStat *pstat;
+    profiler_ts end_ts;
+    uint64_t diff;
+    
+    profiler_ts_get(&end_ts);
+    diff = profiler_ts_diff(start_ts, end_ts);
+    
+    HASH_FIND_STR(profiler_stats, name, pstat);
+    if (!pstat) {
+        pstat = calloc(1, sizeof(struct ProfilerStat));
+        pstat->name = strdup(name);
+        HASH_ADD_KEYPTR(hh, profiler_stats, name, strlen(pstat->name), pstat);
+    }
+    
+    data = malloc(sizeof(struct ProfilerData));
+    data->value = diff;
+    data->ts = end_ts;
+    
+    pstat->count++;
+    pstat->index++;
+    DL_APPEND(pstat->data, data);
+    
+    if (pstat->index > STAT_WINDOW_COUNT) {
+        // pop the oldest entry off the front
+        DL_DELETE(pstat->data, pstat->data);
+        pstat->index--;
+    }
+}
+
+void free_profiler_stats()
+{
+    struct ProfilerStat *pstat, *tmp_pstat;
+    struct ProfilerData *data, *tmp_data;
+    
+    HASH_ITER(hh, profiler_stats, pstat, tmp_pstat) {
+        HASH_DELETE(hh, profiler_stats, pstat);
+        DL_FOREACH_SAFE(pstat->data, data, tmp_data) {
+            DL_DELETE(pstat->data, data);
+            free(data);
+        }
+        free(pstat->name);
+        free(pstat);
+    }
+}
+
+static int int_cmp(const void *a, const void *b)
+{
+    const uint64_t *ia = (const uint64_t *)a;
+    const uint64_t *ib = (const uint64_t *)b;
+    
+    return *ia  - *ib;
+}
+
+static uint64_t percentile(float perc, uint64_t *int_array, int length)
+{
+    uint64_t value;
+    uint64_t *sorted_requests;
+    int index_of_perc;
+    
+    sorted_requests = calloc(length, sizeof(uint64_t));
+    memcpy(sorted_requests, int_array, length * sizeof(uint64_t));
+    qsort(sorted_requests, length, sizeof(uint64_t), int_cmp);
+    index_of_perc = (int)ceil(((perc / 100.0) * length) + 0.5);
+    if (index_of_perc >= length) {
+        index_of_perc = length - 1;
+    }
+    value = sorted_requests[index_of_perc];
+    free(sorted_requests);
+    
+    return value;
+}
+
+struct ProfilerReturn *profiler_get_stats_for_name(const char *name)
+{
+    struct ProfilerStat *pstat;
+    HASH_FIND_STR(profiler_stats, name, pstat);
+    return profiler_get_stats(pstat);
+}
+
+struct ProfilerReturn *profiler_get_stats(struct ProfilerStat *pstat)
+{
+    struct ProfilerData *data;
+    struct ProfilerReturn *ret;
+    uint64_t request_total;
+    profiler_ts cur_ts;
+    uint64_t diff;
+    uint64_t int_array[STAT_WINDOW_COUNT];
+    int valid_count;
+    
+    if (!pstat) {
+        return NULL;
+    }
+    
+    profiler_ts_get(&cur_ts);
+    
+    valid_count = 0;
+    request_total = 0;
+    DL_FOREACH(pstat->data, data) {
+        diff = profiler_ts_diff(data->ts, cur_ts);
+        if (diff < STAT_WINDOW_USEC) {
+            int_array[valid_count++] = data->value;
+            request_total += data->value;
+        }
+    }
+    
+    ret = malloc(sizeof(struct ProfilerReturn));
+    ret->count = pstat->count;
+    if (valid_count) {
+        ret->average = request_total / valid_count;
+        ret->hundred_percent = percentile(100.0, int_array, valid_count);
+        ret->ninety_nine_percent = percentile(99.0, int_array, valid_count);
+        ret->ninety_five_percent = percentile(95.0, int_array, valid_count);
+    } else {
+        ret->average = 0;
+        ret->hundred_percent = 0;
+        ret->ninety_nine_percent = 0;
+        ret->ninety_five_percent = 0;
+    }
+    
+    return ret;
+}
+
+struct ProfilerStat *profiler_stats_get_all()
+{
+    return profiler_stats;
+}
+
+#if _POSIX_TIMERS > 0
+
+    void profiler_ts_get(struct timespec *ts)
+    {
+        clock_gettime(CLOCK_REALTIME, ts);
+    }
+    
+    unsigned int profiler_ts_diff(struct timespec start, struct timespec end)
+    {
+        struct timespec temp;
+        
+        if ((end.tv_nsec - start.tv_nsec) < 0) {
+            temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+            temp.tv_nsec = 1000000000 + end.tv_nsec - start.tv_nsec;
+        } else {
+            temp.tv_sec = end.tv_sec - start.tv_sec;
+            temp.tv_nsec = end.tv_nsec - start.tv_nsec;
+        }
+        
+        // return usec as int
+        return (temp.tv_sec * 1000000) + (temp.tv_nsec / 1000);
+    }
+
+#else
+
+    void profiler_ts_get(struct timeval *ts)
+    {
+        gettimeofday(ts, NULL);
+    }
+    
+    unsigned int profiler_ts_diff(struct timeval start, struct timeval end)
+    {
+        struct timeval temp;
+        
+        if ((end.tv_usec - start.tv_usec) < 0) {
+            temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+            temp.tv_usec = 1000000 + end.tv_usec - start.tv_usec;
+        } else {
+            temp.tv_sec = end.tv_sec - start.tv_sec;
+            temp.tv_usec = end.tv_usec - start.tv_usec;
+        }
+        
+        // return usec as int
+        return (temp.tv_sec * 1000000) + temp.tv_usec;
+    }
+
+#endif

--- a/profiler_stats/profiler_stats.h
+++ b/profiler_stats/profiler_stats.h
@@ -1,0 +1,55 @@
+#ifndef __profiler_stats_h
+#define __profiler_stats_h
+
+#define PROFILER_STATS_VERSION "0.1"
+
+#if _POSIX_TIMERS > 0
+
+    typedef struct timespec profiler_ts;
+    
+    void profiler_ts_get(struct timespec *ts);
+    unsigned int profiler_ts_diff(struct timespec start, struct timespec end);
+
+#else
+
+    typedef struct timeval profiler_ts;
+    
+    void profiler_ts_get(struct timeval *ts);
+    unsigned int profiler_ts_diff(struct timeval start, struct timeval end);
+
+#endif
+
+struct UT_hash_handle;
+
+struct ProfilerReturn {
+    uint64_t count;
+    uint64_t average;
+    uint64_t hundred_percent;
+    uint64_t ninety_nine_percent;
+    uint64_t ninety_five_percent;
+};
+
+struct ProfilerData {
+    uint64_t value;
+    profiler_ts ts;
+    struct ProfilerData *prev;
+    struct ProfilerData *next;
+};
+
+struct ProfilerStat {
+    char *name;
+    struct ProfilerData *data;
+    uint64_t count;
+    int index;
+    UT_hash_handle hh;
+    struct ProfilerStat *next;
+};
+
+void profiler_stats_reset();
+void profiler_stats_store(const char *name, profiler_ts start_ts);
+struct ProfilerReturn *profiler_get_stats_for_name(const char *name);
+struct ProfilerReturn *profiler_get_stats(struct ProfilerStat *pstat);
+struct ProfilerStat *profiler_stats_get_all();
+void free_profiler_stats();
+
+#endif


### PR DESCRIPTION
im opening this completed, entirely, utterly untested.  thats just how we roll.

also - note that I left the `simplehttp` stats alone but I'm going to do the work to move `simplehttp` as well as any other apps to `profiler_stats`
