### PR TITLE
Added fwmatch endpoint to simpleleveldb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ simpleleveldb/simpleleveldb
 simpleleveldb/leveldb_to_csv
 simpleleveldb/csv_to_leveldb
 test_output
+.sw[op]

--- a/simpleleveldb/Makefile
+++ b/simpleleveldb/Makefile
@@ -5,7 +5,7 @@ LIBSIMPLEHTTP_INC ?= $(LIBSIMPLEHTTP)/..
 LIBSIMPLEHTTP_LIB ?= $(LIBSIMPLEHTTP)
 LIBLEVELDB ?= /usr/local
 
-CFLAGS = -I. -I$(LIBSIMPLEHTTP_INC) -I$(LIBEVENT)/include -I$(LIBLEVELDB)/include -Wall -g -O2
+CFLAGS = -I. -I$(LIBSIMPLEHTTP_INC) -I$(LIBEVENT)/include -I$(LIBLEVELDB)/include -Wall -g -O2 
 LIBS = -L. -L$(LIBSIMPLEHTTP_LIB) -L$(LIBEVENT)/lib -L/usr/local/lib -L$(LIBLEVELDB)/lib -levent -ljson -lsimplehttp -lleveldb -lm -lstdc++ -lsnappy
 AR = ar
 AR_FLAGS = rc

--- a/simpleleveldb/test_simpleleveldb.py
+++ b/simpleleveldb/test_simpleleveldb.py
@@ -23,6 +23,8 @@ class SimpleLeveldbTest(SubprocessTest):
         http_fetch_json("/put", dict(), 400, 'MISSING_ARG_KEY')
         http_fetch_json("/put", dict(key='test'), 400, 'MISSING_ARG_VALUE')
         http_fetch_json("/get", dict(), 400, 'MISSING_ARG_KEY')
+
+        http_fetch_json("/fwmatch", dict(), 400, 'MISSING_ARG_KEY')
         
         http_fetch_json('/put', dict(key='test1', value='asdf1'))
         http_fetch_json('/put', dict(key='test2', value='asdf2'))
@@ -30,6 +32,10 @@ class SimpleLeveldbTest(SubprocessTest):
         data = http_fetch('/mget', dict(key=['test1', 'test2', 'test3'], format='txt'))
         print data
         assert data == 'test1,asdf1\ntest2,asdf2\n'
+
+        data = http_fetch_json("/fwmatch", dict(key="test"))
+        print data
+        assert data == [{'test1': 'asdf1'}, {'test2': 'asdf2'}]
         
         
         # test list stuff


### PR DESCRIPTION
SimpleLevelDB now has a new fwmatch endpoint that takes in parameters:
- key = string to do the forward match on
- limit = integer for maximum results to be returned.  Default = 500.  limit = 0 means no limit.
