### PR TITLE
Add mlock/munlock support to peg data file into memory

### DIFF
--- a/sortdb/sortdb.c
+++ b/sortdb/sortdb.c
@@ -378,6 +378,7 @@ int main(int argc, char **argv)
     option_define_str("db_file", OPT_REQUIRED, NULL, &db_filename, NULL, NULL);
     option_define_bool("memory_lock", OPT_OPTIONAL, 0, NULL, NULL, "lock data file pages into memory");
     option_define_char("field_separator", OPT_OPTIONAL, '\0', &deliminator, NULL, "field separator (eg: comma, tab, pipe). default: TAB");
+    option_define_bool("version", OPT_OPTIONAL, 0, NULL, version_cb, VERSION);
 
     if (!option_parse_command_line(argc, argv)) {
         return 1;


### PR DESCRIPTION
Add a command line option to enable, and support for locking data file pages into memory
