### PR TITLE
New Endpoints!

### DIFF
--- a/simpleleveldb/README.md
+++ b/simpleleveldb/README.md
@@ -58,11 +58,23 @@ API endpoints:
 
     parameters: `key` (multiple), `format`
 
+ * /fwmatch
+
+    parameters: `key`, `limit`
+
+ * /range_match
+
+    parameters: `start`, `end`, `limit`
+
  * /put
 
     parameters: `key`, `value`, `format`
     
     Note: `value` can also be specified as the raw POST body content
+
+ * /mput
+    
+    takes CSV values in the body of the request.
 
  * /del
 


### PR DESCRIPTION
New endpoints added.  They are:
- mputs
- range_match

mputs allows multiple inserts based off of the comma delineated body of
the http request to the endpoint.

range_match allows a slice of the database to be returned where "start"
and "end" are the ranges of the lexicographical match.
