### PR TITLE
Changed ps_to_http to select random source

### DIFF
--- a/ps_to_http/.gitignore
+++ b/ps_to_http/.gitignore
@@ -1,0 +1,2 @@
+*.sw[po]
+ps_to_http

--- a/ps_to_http/README.md
+++ b/ps_to_http/README.md
@@ -18,7 +18,7 @@ OPTIONS
   --destination-post-url=<str> (multiple) url(s) to HTTP POST to
                          For a pubsub endpoint use "http://127.0.0.1:8080/pub"
   --help                 list usage
-  --pubsub-url=<str>     url of pubsub to read from
+  --pubsub-url=<str>     (multiple) pubsub url(s) to read from
                          default: http://127.0.0.1:80/sub?multipart=0
   --round-robin          write round-robin to destination urls
   --max-silence          Maximum amount of time (in seconds) between messages from


### PR DESCRIPTION
Because of strange problems with `ps_to_http` not properly switching to
the secondary pubsub we now just make a random pubsub selection from a
list.  This way when daemon tools restarts ps_to_http we have a
reasonable chance of switching sources.
