### PR TITLE
simpleleveldb memory growth

### DIFF
--- a/simpleleveldb/README.md
+++ b/simpleleveldb/README.md
@@ -1,7 +1,14 @@
 simpleleveldb
 =============
 
-HTTP based leveldb server. 
+HTTP based leveldb server.
+
+NOTE: there is a known issue with long-running leveldb processes resulting 
+in unbounded memory growth of the process.  This is due to the fact that 
+the MANIFEST file is never compacted.  We've provided a `/hup` handler that 
+will close and re-open the database (twice) in order to trigger compaction 
+and removal of the MANIFEST.  
+(see [issue #70](https://github.com/bitly/simplehttp/issues/70))
 
 Building
 --------


### PR DESCRIPTION
it appears that due to the fact that `leveldb` does not rotate it's `MANIFEST` file there is some inherent lack of cleanup/accounting for orphaned ss tables (presumably kept in memory as well).

to address this, for `simpleleveldb`, we can add a HUP signal handler that will close and re-open the database.
