### PR TITLE
Mac compatability in Makefiles

### DIFF
--- a/ps_to_file/Makefile
+++ b/ps_to_file/Makefile
@@ -12,7 +12,8 @@ ps_to_file: ps_to_file.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 install:
-	/usr/bin/install -D ps_to_file $(TARGET)/bin/ps_to_file
+	/usr/bin/install -d $(TARGET)/bin/
+	/usr/bin/install ps_to_file $(TARGET)/bin/
 
 clean:
 	rm -f *.o *.a ps_to_file

--- a/ps_to_http/Makefile
+++ b/ps_to_http/Makefile
@@ -12,7 +12,8 @@ ps_to_http: ps_to_http.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 install:
-	/usr/bin/install -D ps_to_http $(TARGET)/bin/ps_to_http
+	/usr/bin/install -d $(TARGET)/bin/
+	/usr/bin/install ps_to_http $(TARGET)/bin/
 
 clean:
 	rm -rf *.o ps_to_http *.dSYM


### PR DESCRIPTION
Changed `install -D` to `install -d` for compatibility. 
