### PR TITLE
Simple change for compatibility with newer tornado

### DIFF
--- a/pysimplehttp/src/__init__.py
+++ b/pysimplehttp/src/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 import file_to_simplequeue
 import pubsub_reader

--- a/pysimplehttp/src/file_to_simplequeue.py
+++ b/pysimplehttp/src/file_to_simplequeue.py
@@ -11,7 +11,7 @@ except ImportError:
     import json
 
 class FileToSimplequeue(object):
-    http = tornado.httpclient.AsyncHTTPClient(max_simultaneous_connections=50, max_clients=50)
+    http = tornado.httpclient.AsyncHTTPClient()
     def __init__(self, input_file, max_concurrent, max_queue_depth, simplequeue_urls,
                 check_simplequeue_interval, stats_interval, filter_require=None, filter_exclude=None, io_loop=None):
         assert isinstance(simplequeue_urls, (list, tuple))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 # upload .tar.gz to github
 # run python setup.py register to update pypi
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 scripts = ['pysimplehttp/scripts/ps_to_sq.py', 
            'pysimplehttp/scripts/file_to_sq.py']
 


### PR DESCRIPTION
I removed the last traces of keyword arguments to `tornado.http.AsyncHTTPClient`.  This should be changed to a `tornado.http.AsyncHTTPClient.configure` call in the future.
