### PR TITLE
logging segfault

### DIFF
--- a/simplehttp/log.c
+++ b/simplehttp/log.c
@@ -65,7 +65,7 @@ void simplehttp_log(const char *host, struct evhttp_request *req, uint64_t req_t
     
     fprintf(stdout, "[%c %s %s] %d %s %s%s", code, datetime_buf, id, response_code, method, host, uri);
     
-    if (display_post && (type == EVHTTP_REQ_POST)) {
+    if (display_post && (type == EVHTTP_REQ_POST) && EVBUFFER_DATA(req->input_buffer)) {
         fprintf(stdout, "?");
         fwrite(EVBUFFER_DATA(req->input_buffer), EVBUFFER_LENGTH(req->input_buffer), 1, stdout);
     }


### PR DESCRIPTION
a POST request tried to log but its evbuffer was NULL...

```
Program terminated with signal 11, Segmentation fault.
#0  0x0000003bc4e7ba7b in mempcpy () from /lib64/libc.so.6
(gdb) bt
#0  0x0000003bc4e7ba7b in mempcpy () from /lib64/libc.so.6
#1  0x0000003bc4e6cfe6 in _IO_new_file_xsputn () from /lib64/libc.so.6
#2  0x0000003bc4e6234b in fwrite () from /lib64/libc.so.6
#3  0x0000000000405fd3 in simplehttp_log ()
#4  0x00000000004066d8 in simplehttp_request_finish ()
#5  0x0000000000406755 in simplehttp_async_finish ()
#6  0x0000000000402b3c in finish_incr_cb (req=0xe15e850, cb_arg=0x0) at ctron_api.c:227
#7  0x000000000040594a in free_async_callback_group ()
#8  0x0000000000405d25 in finish_async_request ()
#9  0x00002ac9073e05e8 in evhttp_connection_done (evcon=0xe157da0) at http.c:775
#10 0x00002ac9073e0edf in evhttp_read_body (evcon=0xe157da0, req=0xe0adbe0) at http.c:905
#11 0x00002ac9073e1009 in evhttp_get_body (evcon=0xe157da0, req=0xe0adbe0) at http.c:1607
#12 0x00002ac9073da708 in event_process_active (base=0xe04b060, flags=0) at event.c:395
#13 event_base_loop (base=0xe04b060, flags=0) at event.c:547
#14 0x0000000000405463 in simplehttp_run ()
#15 0x000000000040548e in simplehttp_main ()
#16 0x000000000040306f in main (argc=5, argv=0x7fff3f5f5e38) at ctron_api.c:614
(gdb) f 6
#6  0x0000000000402b3c in finish_incr_cb (req=0xe15e850, cb_arg=0x0) at ctron_api.c:227
227 ctron_api.c: No such file or directory.
    in ctron_api.c
(gdb) p *req
$1 = {next = {tqe_next = 0xe174da0, tqe_prev = 0xe1668c0}, evcon = 0xe089ca0, flags = 1, input_headers = 0xe16d310, output_headers = 0xe1a5b50, remote_host = 0xe1a59b0 "P\207\030\016", 
  remote_port = 41311, kind = EVHTTP_RESPONSE, type = EVHTTP_REQ_POST, uri = 0xe09af90 "0\036\n\016", major = 1 '\001', minor = 0 '\000', response_code = 500, 
  response_code_line = 0xe174e20 "\240\225\016\016", input_buffer = 0xe16d330, ntoread = 0, chunked = 0, userdone = -1, output_buffer = 0xe1559b0, 
  cb = 0x2ac9073e07e0 <evhttp_handle_request>, cb_arg = 0xe04c1a0, chunk_cb = 0xa0}
(gdb) p *req->input_buffer
$2 = {buffer = 0x0, 
  orig_buffer = 0xe1b5aa0 "count=1&subtotal_key=h.es%7Csbnation%2Fsbnation%2F_ALL.SMKBQn&subtotal_key=h.es%7Csbnation%2Fsbnation%2F_ALL.SNjxAm&subtotal_key=h.es%7Csbnation%2Fsbnation%2F_ALL.SPBgXY&subtotal_key=h.es%7Csbnation%2"..., misalign = 0, totallen = 8192, off = 5744, cb = 0, cbarg = 0x0}
```
